### PR TITLE
feat: JPA Entity, Repository 추가

### DIFF
--- a/src/main/java/dev/sijunyang/celog/core/domain/bookmark/BookMarkEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/bookmark/BookMarkEntity.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "tbl_bookmark")
+@Entity(name = "bookmark")
 public class BookMarkEntity extends BaseCreateTimeEntity {
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/bookmark/BookMarkEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/bookmark/BookMarkEntity.java
@@ -1,0 +1,52 @@
+package dev.sijunyang.celog.core.domain.bookmark;
+
+import dev.sijunyang.celog.core.global.jpa.BaseCreateTimeEntity;
+import dev.sijunyang.celog.core.domain.user.UserEntity;
+import dev.sijunyang.celog.core.domain.post.PostEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * {@link UserEntity}와 {@link PostEntity} 간의 북마크 관계를 나타내는 엔티티 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "tbl_bookmark")
+public class BookMarkEntity extends BaseCreateTimeEntity {
+
+    /**
+     * 북마크 엔티티의 고유 식별자입니다.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 북마크를 설정한 사용자의 고유 식별자입니다.
+     */
+    @NotNull
+    private Long userId;
+
+    /**
+     * 북마크된 포스트의 고유 식별자입니다.
+     */
+    @NotNull
+    private Long postId;
+
+    @Builder
+    public BookMarkEntity(Long id, Long userId, Long postId) {
+        this.id = id;
+        this.userId = userId;
+        this.postId = postId;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/bookmark/BookMarkEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/bookmark/BookMarkEntity.java
@@ -1,8 +1,8 @@
 package dev.sijunyang.celog.core.domain.bookmark;
 
-import dev.sijunyang.celog.core.global.jpa.BaseCreateTimeEntity;
-import dev.sijunyang.celog.core.domain.user.UserEntity;
 import dev.sijunyang.celog.core.domain.post.PostEntity;
+import dev.sijunyang.celog.core.domain.user.UserEntity;
+import dev.sijunyang.celog.core.global.jpa.BaseCreateTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;

--- a/src/main/java/dev/sijunyang/celog/core/domain/bookmark/BookMarkRepository.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/bookmark/BookMarkRepository.java
@@ -1,0 +1,12 @@
+package dev.sijunyang.celog.core.domain.bookmark;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * {@link BookMarkEntity}를 처리하는 JpaRepository입니다.
+ *
+ * @author Sijun Yang
+ */
+public interface BookMarkRepository extends JpaRepository<BookMarkEntity, Long> {
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/bookmark/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/bookmark/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 북마크 기능의 중심이 되는 패키지입니다.
+ */
+package dev.sijunyang.celog.core.domain.bookmark;

--- a/src/main/java/dev/sijunyang/celog/core/domain/follow/FollowEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/follow/FollowEntity.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "tbl_follow")
+@Entity(name = "follow")
 public class FollowEntity extends BaseCreateTimeEntity {
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/follow/FollowEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/follow/FollowEntity.java
@@ -1,0 +1,51 @@
+package dev.sijunyang.celog.core.domain.follow;
+
+import dev.sijunyang.celog.core.domain.user.UserEntity;
+import dev.sijunyang.celog.core.global.jpa.BaseCreateTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 두 {@link UserEntity} 사이의 팔로우 관계를 나타내는 엔티티 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "tbl_follow")
+public class FollowEntity extends BaseCreateTimeEntity {
+
+    /**
+     * 팔로우 엔티티의 고유 식별자입니다.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 팔로우 되는 사용자의 고유 식별자입니다.
+     */
+    @NotNull
+    private Long followerId;
+
+    /**
+     * 팔로우하는 사용자의 고유 식별자입니다.
+     */
+    @NotNull
+    private Long followingId;
+
+    @Builder
+    public FollowEntity(Long id, Long followerId, Long followingId) {
+        this.id = id;
+        this.followerId = followerId;
+        this.followingId = followingId;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/follow/FollowRepository.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/follow/FollowRepository.java
@@ -1,0 +1,12 @@
+package dev.sijunyang.celog.core.domain.follow;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * {@link FollowEntity}를 처리하는 JpaRepository입니다.
+ *
+ * @author Sijun Yang
+ */
+public interface FollowRepository extends JpaRepository<FollowEntity, Long> {
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/follow/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/follow/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 팔로우 기능의 중심이 되는 패키지입니다.
+ */
+package dev.sijunyang.celog.core.domain.follow;

--- a/src/main/java/dev/sijunyang/celog/core/domain/hashtag/HashtagEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/hashtag/HashtagEntity.java
@@ -1,0 +1,43 @@
+package dev.sijunyang.celog.core.domain.hashtag;
+
+import dev.sijunyang.celog.core.global.jpa.BaseCreateTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 해시태그 정보를 저장하는 엔티티입니다.
+ *
+ * @author Sijun Yang
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "tbl_hashtag")
+public class HashtagEntity extends BaseCreateTimeEntity {
+
+    /**
+     * 해시태그의 고유 식별자입니다.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 해시태그 이름입니다.
+     */
+    @NotNull
+    private String name;
+
+    @Builder
+    public HashtagEntity(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/hashtag/HashtagEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/hashtag/HashtagEntity.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "tbl_hashtag")
+@Entity(name = "hashtag")
 public class HashtagEntity extends BaseCreateTimeEntity {
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/hashtag/HashtagRepository.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/hashtag/HashtagRepository.java
@@ -1,0 +1,12 @@
+package dev.sijunyang.celog.core.domain.hashtag;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * {@link HashtagEntity}를 처리하는 JpaRepository입니다.
+ *
+ * @author Sijun Yang
+ */
+public interface HashtagRepository extends JpaRepository<HashtagEntity, Long> {
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/hashtag/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/hashtag/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 해시태그 기능의 중심이 되는 패키지입니다.
+ */
+package dev.sijunyang.celog.core.domain.hashtag;

--- a/src/main/java/dev/sijunyang/celog/core/domain/notification/NotificationEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/notification/NotificationEntity.java
@@ -1,0 +1,52 @@
+package dev.sijunyang.celog.core.domain.notification;
+
+import dev.sijunyang.celog.core.global.jpa.BaseCreateTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 알림 정보를 저장하는 엔티티 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "tbl_notification")
+public class NotificationEntity extends BaseCreateTimeEntity {
+
+    /**
+     * 알림의 고유 식별자입니다.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 알림 내용입니다.
+     */
+    @NotNull
+    @Column(length = 1024)
+    private String content;
+
+    /**
+     * 알림을 읽었는지 여부를 나타냅니다. true면 읽음, false면 읽지 않음 상태를 의미합니다.
+     */
+    @NotNull
+    private Boolean readStatus;
+
+    @Builder
+    public NotificationEntity(Long id, String content, Boolean readStatus) {
+        this.id = id;
+        this.content = content;
+        this.readStatus = readStatus;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/notification/NotificationEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/notification/NotificationEntity.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "tbl_notification")
+@Entity(name = "notification")
 public class NotificationEntity extends BaseCreateTimeEntity {
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/notification/NotificationRepository.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/notification/NotificationRepository.java
@@ -1,0 +1,12 @@
+package dev.sijunyang.celog.core.domain.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * {@link NotificationEntity}를 처리하는 JpaRepository입니다.
+ *
+ * @author Sijun Yang
+ */
+public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/notification/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/notification/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 알림 기능의 중심이 되는 패키지입니다.
+ */
+package dev.sijunyang.celog.core.domain.notification;

--- a/src/main/java/dev/sijunyang/celog/core/domain/post/PostEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/post/PostEntity.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 /**
  * 포스트(게시글) 정보를 저장하는 엔티티 클래스입니다.
  *
+ * @see PostHashtagEntity
  * @author Sijun Yang
  */
 @Getter

--- a/src/main/java/dev/sijunyang/celog/core/domain/post/PostEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/post/PostEntity.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "tbl_post")
+@Entity(name = "post")
 public class PostEntity extends BaseTimeEntity {
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/post/PostEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/post/PostEntity.java
@@ -1,0 +1,70 @@
+package dev.sijunyang.celog.core.domain.post;
+
+import dev.sijunyang.celog.core.global.enums.PublicationStatus;
+import dev.sijunyang.celog.core.global.jpa.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 포스트(게시글) 정보를 저장하는 엔티티 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "tbl_post")
+public class PostEntity extends BaseTimeEntity {
+
+    /**
+     * 포스트의 고유 식별자입니다.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 포스트 제목입니다.
+     */
+    @NotNull
+    private String title;
+
+    /**
+     * 포스트 내용입니다.
+     */
+    @NotNull
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    /**
+     * 포스트 공개 상태를 나타냅니다.
+     */
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private PublicationStatus readStatus;
+
+    /**
+     * 포스트를 작성한 사용자의 고유 식별자입니다.
+     */
+    @NotNull
+    private Long userId;
+
+    @Builder
+    public PostEntity(Long id, String title, String content, PublicationStatus readStatus, Long userId) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.readStatus = readStatus;
+        this.userId = userId;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/post/PostEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/post/PostEntity.java
@@ -18,8 +18,8 @@ import lombok.NoArgsConstructor;
 /**
  * 포스트(게시글) 정보를 저장하는 엔티티 클래스입니다.
  *
- * @see PostHashtagEntity
  * @author Sijun Yang
+ * @see PostHashtagEntity
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/dev/sijunyang/celog/core/domain/post/PostHashtagEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/post/PostHashtagEntity.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "tbl_post_hashtag")
+@Entity(name = "post_hashtag")
 public class PostHashtagEntity {
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/post/PostHashtagEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/post/PostHashtagEntity.java
@@ -1,0 +1,53 @@
+package dev.sijunyang.celog.core.domain.post;
+
+import dev.sijunyang.celog.core.domain.hashtag.HashtagEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 게시글과 해시태그 간의 관계를 나타내는 엔티티입니다. <br/>
+ * 하나의 게시글은 여러 개의 해시태그를 가지거나 아무 해시태그도 가지지 않을 수 있습니다.
+ *
+ * @author Sijun Yang
+ * @see PostEntity
+ * @see HashtagEntity
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "tbl_post_hashtag")
+public class PostHashtagEntity {
+
+    /**
+     * 게시글-해시태그 관계의 고유 식별자입니다.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 해시태그를 사용하는 포스트의 고유 식별자입니다.
+     */
+    @NotNull
+    private Long postId;
+
+    /**
+     * 포스트가 사용하는 해시태그의 식별자입니다.
+     */
+    @NotNull
+    private Long hashtagId;
+
+    @Builder
+    public PostHashtagEntity(Long id, Long postId, Long hashtagId) {
+        this.id = id;
+        this.postId = postId;
+        this.hashtagId = hashtagId;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/post/PostHashtagRepository.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/post/PostHashtagRepository.java
@@ -1,0 +1,12 @@
+package dev.sijunyang.celog.core.domain.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * {@link PostHashtagEntity}를 처리하는 JpaRepository입니다.
+ *
+ * @author Sijun Yang
+ */
+public interface PostHashtagRepository extends JpaRepository<PostHashtagEntity, Long> {
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/post/PostRepository.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/post/PostRepository.java
@@ -1,0 +1,12 @@
+package dev.sijunyang.celog.core.domain.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * {@link PostEntity}를 처리하는 JpaRepository입니다.
+ *
+ * @author Sijun Yang
+ */
+public interface PostRepository extends JpaRepository<PostEntity, Long> {
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/post/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/post/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 글 기능의 중심이 되는 패키지입니다.
+ */
+package dev.sijunyang.celog.core.domain.post;

--- a/src/main/java/dev/sijunyang/celog/core/domain/reply/ReplyEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/reply/ReplyEntity.java
@@ -1,0 +1,66 @@
+package dev.sijunyang.celog.core.domain.reply;
+
+import dev.sijunyang.celog.core.global.jpa.BaseTimeEntity;
+import dev.sijunyang.celog.core.domain.post.PostEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * 어떤 {@link PostEntity}에 대한 댓글 정보를 저장하는 엔티티 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "tbl_reply")
+public class ReplyEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 댓글 내용입니다.
+     */
+    @NotNull
+    @Column(length = 4096)
+    private String content;
+
+    /**
+     * 댓글을 작성한 사용자의 고유 식별자입나다.
+     */
+    @NotNull
+    private Long userId;
+
+    /**
+     * 댓글이 작성된 포스트의 고유 식별자입니다.
+     */
+    @NotNull
+    private Long postId;
+
+    /**
+     * 대댓글인 경우, 상위 댓글의 고유 식별자입니다. 상위 댓글이 없는 경우 null 입니다.
+     */
+    @Nullable
+    private Long superReplyId;
+
+    @Builder
+    public ReplyEntity(Long id, String content, Long userId, Long postId, @Nullable Long superReplyId) {
+        this.id = id;
+        this.content = content;
+        this.userId = userId;
+        this.postId = postId;
+        this.superReplyId = superReplyId;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/reply/ReplyEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/reply/ReplyEntity.java
@@ -22,7 +22,7 @@ import org.springframework.lang.Nullable;
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "tbl_reply")
+@Entity(name = "reply")
 public class ReplyEntity extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/dev/sijunyang/celog/core/domain/reply/ReplyEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/reply/ReplyEntity.java
@@ -1,7 +1,7 @@
 package dev.sijunyang.celog.core.domain.reply;
 
-import dev.sijunyang.celog.core.global.jpa.BaseTimeEntity;
 import dev.sijunyang.celog.core.domain.post.PostEntity;
+import dev.sijunyang.celog.core.global.jpa.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/dev/sijunyang/celog/core/domain/reply/ReplyRepository.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/reply/ReplyRepository.java
@@ -1,0 +1,12 @@
+package dev.sijunyang.celog.core.domain.reply;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * {@link ReplyEntity}를 처리하는 JpaRepository입니다.
+ *
+ * @author Sijun Yang
+ */
+public interface ReplyRepository extends JpaRepository<ReplyEntity, Long> {
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/reply/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/reply/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 댓글 기능의 중심이 되는 패키지입니다.
+ */
+package dev.sijunyang.celog.core.domain.reply;

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/OauthUser.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/OauthUser.java
@@ -1,0 +1,36 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자의 OAuth 관련 정보를 저장하는 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class OauthUser {
+
+    /**
+     * OAuth 제공자의 이름입니다.
+     */
+    @NotNull
+    private String oauthProviderName;
+
+    /**
+     * OAuth 제공자로부터 받은 사용자 ID입니다.
+     */
+    @NotNull
+    private String oauthUserId;
+
+    public OauthUser(String oauthProviderName, String oauthUserId) {
+        this.oauthProviderName = oauthProviderName;
+        this.oauthUserId = oauthUserId;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
@@ -1,0 +1,94 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import dev.sijunyang.celog.core.global.enums.AuthenticationType;
+import dev.sijunyang.celog.core.global.jpa.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * 사용자 정보를 저장하는 엔티티 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "tbl_user")
+public class UserEntity extends BaseTimeEntity {
+
+    /**
+     * 사용자의 고유 식별자입니다.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 사용자 이름입니다.
+     */
+    @NotNull
+    private String name;
+
+    /**
+     * 사용자 이메일입니다.
+     */
+    @Nullable
+    @Column(unique = true)
+    private String email;
+
+    /**
+     * 사용자의 OAuth 관련 정보를 저장합니다. OAuth로 가입하지 않은 사용자는 null 입니다.
+     */
+    @Nullable
+    @Embedded
+    private OauthUser oauthUser;
+
+    /**
+     * 사용자 프로필 URL입니다.
+     */
+    @Nullable
+    @Column(length = 1024)
+    private String profileUrl;
+
+    /**
+     * 사용자 인증 유형을 나타냅니다.
+     */
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private AuthenticationType authenticationType;
+
+    @Builder
+    public UserEntity(Long id, String name, @Nullable String email, @Nullable OauthUser oauthUser,
+            @Nullable String profileUrl, AuthenticationType authenticationType) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.oauthUser = oauthUser;
+        this.profileUrl = profileUrl;
+        this.authenticationType = authenticationType;
+    }
+
+    /**
+     * 사용자 인증 정보의 유효성을 검증합니다. <br/>
+     * email과 oauthUser 중 하나는 반드시 null이 아니어야 합니다.
+     * @return 유효성 검증 결과
+     */
+    @AssertTrue(message = "email, oauthUser 두 필드 중 하나는 null이 아니여야만 합니다.")
+    private boolean valid() {
+        return !(this.email == null && this.oauthUser == null);
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
@@ -1,6 +1,7 @@
 package dev.sijunyang.celog.core.domain.user;
 
 import dev.sijunyang.celog.core.global.enums.AuthenticationType;
+import dev.sijunyang.celog.core.global.enums.Role;
 import dev.sijunyang.celog.core.global.jpa.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -70,15 +71,23 @@ public class UserEntity extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private AuthenticationType authenticationType;
 
+    /**
+     * 사용자 인증 권한을 나타냅니다.
+     */
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
     @Builder
     public UserEntity(Long id, String name, @Nullable String email, @Nullable OauthUser oauthUser,
-            @Nullable String profileUrl, AuthenticationType authenticationType) {
+            @Nullable String profileUrl, AuthenticationType authenticationType, Role role) {
         this.id = id;
         this.name = name;
         this.email = email;
         this.oauthUser = oauthUser;
         this.profileUrl = profileUrl;
         this.authenticationType = authenticationType;
+        this.role = role;
     }
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
@@ -26,7 +26,7 @@ import org.springframework.lang.Nullable;
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "users") // user는 h2, mysql의 예약어이므로 사용할 수 없음
+@Entity(name = "users") // user는 h2 예약어이므로 사용할 수 없음
 public class UserEntity extends BaseTimeEntity {
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
@@ -26,7 +26,7 @@ import org.springframework.lang.Nullable;
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "tbl_user")
+@Entity(name = "users") // user는 h2, mysql의 예약어이므로 사용할 수 없음
 public class UserEntity extends BaseTimeEntity {
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserRepository.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserRepository.java
@@ -1,0 +1,12 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * {@link UserEntity}를 처리하는 JpaRepository입니다.
+ *
+ * @author Sijun Yang
+ */
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 사용자 기능의 중심이 되는 패키지입니다.
+ */
+package dev.sijunyang.celog.core.domain.user;

--- a/src/main/java/dev/sijunyang/celog/core/global/enums/AuthenticationType.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/enums/AuthenticationType.java
@@ -1,0 +1,27 @@
+package dev.sijunyang.celog.core.global.enums;
+
+import dev.sijunyang.celog.core.domain.user.UserEntity;
+
+/**
+ * {@link UserEntity}의 인증 유형을 나타내는 Enum 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+public enum AuthenticationType {
+
+    /**
+     * 이메일 인증 유형입니다.
+     */
+    EMAIL,
+
+    /**
+     * GitHub OAuth 인증 유형입니다.
+     */
+    OAUTH_GITHUB,
+
+    /**
+     * Google OAuth 인증 유형입니다.
+     */
+    OAUTH_GOOGLE;
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/enums/PublicationStatus.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/enums/PublicationStatus.java
@@ -1,0 +1,22 @@
+package dev.sijunyang.celog.core.global.enums;
+
+import dev.sijunyang.celog.core.domain.post.PostEntity;
+
+/**
+ * {@link PostEntity}의 공개 상태를 나타내는 Enum 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+public enum PublicationStatus {
+
+    /**
+     * 모든 사용자에게 공개된 게시물 상태입니다.
+     */
+    PUBLIC_PUBLISHED,
+
+    /**
+     * 작성 중인 게시물 상태입니다.
+     */
+    DRAFTING;
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/enums/Role.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/enums/Role.java
@@ -1,0 +1,20 @@
+package dev.sijunyang.celog.core.global.enums;
+
+/**
+ * Role은 사용자 권한을 나타내는 enum class입니다.
+ *
+ * @author Sijun Yang
+ */
+public enum Role {
+
+    /**
+     * 일반 사용자 권한입니다.
+     */
+    USER,
+
+    /**
+     * 관리자 권한입니다.
+     */
+    ADMIN,;
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/enums/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/enums/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * celog 프로젝트 전반에서 사용되는 Enum 클래스를 가지는 패키지입니다.
+ */
+package dev.sijunyang.celog.core.global.enums;

--- a/src/main/java/dev/sijunyang/celog/core/global/jpa/BaseCreateTimeEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/jpa/BaseCreateTimeEntity.java
@@ -1,0 +1,28 @@
+package dev.sijunyang.celog.core.global.jpa;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 생성 시간을 기록하는 엔티티를 위한 기본 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseCreateTimeEntity {
+
+    /**
+     * 엔티티가 생성된 시간입니다.
+     */
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/jpa/BaseTimeEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/jpa/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package dev.sijunyang.celog.core.global.jpa;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 생성 시간과 수정 시간을 기록하는 엔티티를 위한 기본 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity extends BaseCreateTimeEntity {
+
+    /**
+     * 엔티티가 마지막으로 수정된 시간입니다.
+     */
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/jpa/JpaAuditingConfig.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/jpa/JpaAuditingConfig.java
@@ -1,0 +1,15 @@
+package dev.sijunyang.celog.core.global.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+/**
+ * {@link EnableJpaAuditing} 어노테이션을 사용하여 Spring Data JPA의 Auditing 기능을 활성화합니다.
+ *
+ * @author Sijun Yang
+ */
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/jpa/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/jpa/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * jpa의 설정과 핵심 기능을 지원하는 패키지입니다.
+ */
+package dev.sijunyang.celog.core.global.jpa;


### PR DESCRIPTION
### 설명

모든 도메인의 Entity, Repository를 구현하였습니다.

Jpa Auditing 기능을 사용하요 생성/수정 일시를 관리하는 기본 엔티티 `BaseCreateTimeEntity`, `BaseTimeEntity`를 정의하고, 
다른 엔티티는 해당 기본 엔티티를 상속받아 구현합니다.

테이블은 `tbl_` 접두사를 가집니다. 일부 테이블의 이름이 데이터베이스의 예약어를 사용하지 않기 위해서 사용합니다.

테스트 코드는 이후 PR로 구현하도록 하겠습니다. 
작업 단위가 커지기도 하고, 현재 테스트 코드 작성에 어려움이 있는 상황입니다.

Fixes #4
