### PR TITLE
Redis Session 적용

### DIFF
--- a/src/main/java/dev/sijunyang/celog/core/global/redis/RedisConfig.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/redis/RedisConfig.java
@@ -1,0 +1,34 @@
+package dev.sijunyang.celog.core.global.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+
+/**
+ * Redis 관련 Bean을 생성하는 Configuration 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory();
+        connectionFactory.afterPropertiesSet(); // 나머지 설정은 기본값 사용
+        return connectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setDefaultSerializer(new JdkSerializationRedisSerializer());
+        template.afterPropertiesSet();
+        return template;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/redis/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/redis/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * redis의 설정과 redis 의존 기능을 지원하는 패키지입니다.
+ */
+package dev.sijunyang.celog.core.global.redis;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,3 @@
-
+spring:
+  session:
+    store-type: redis


### PR DESCRIPTION
#### 설명

Redis의 Configuration 클래스를 작성하고,
`application.yml`에  Redis Session을 사용하기 위한 프로퍼티를 설정하였습니다.

#### 실행

<img width="1356" alt="image" src="https://github.com/f-lab-edu/celog/assets/80192911/afcbbf5e-0017-4a2e-9a13-2cd92d11b659">

로컬 환경에서 적용되는 것을 확인했습니다.

Fixes #6 