### PR TITLE
feat: 예외처리 기능 구현

### DIFF
--- a/src/main/java/dev/sijunyang/celog/api/error/RestExceptionHandlerAdvice.java
+++ b/src/main/java/dev/sijunyang/celog/api/error/RestExceptionHandlerAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 /**
  * RESTful API에서 발생하는 예외 상황을 처리하기 위한 전역 예외 핸들러 클래스입니다.
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
  * @author Sijun Yang
  */
 @ControllerAdvice
-public class RestExceptionHandlerAdvice {
+public class RestExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
 
     /**
      * 예상치 못한 예외 발생 시 처리하는 핸들러 메서드입니다. 500 Internal Server Error 응답을 반환합니다.

--- a/src/main/java/dev/sijunyang/celog/api/error/RestExceptionHandlerAdvice.java
+++ b/src/main/java/dev/sijunyang/celog/api/error/RestExceptionHandlerAdvice.java
@@ -1,0 +1,101 @@
+package dev.sijunyang.celog.api.error;
+
+import dev.sijunyang.celog.core.global.error.BadRequestException;
+import dev.sijunyang.celog.core.global.error.ConflictException;
+import dev.sijunyang.celog.core.global.error.ForbiddenException;
+import dev.sijunyang.celog.core.global.error.NotFoundException;
+import dev.sijunyang.celog.core.global.error.UnauthenticatedException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+/**
+ * RESTful API에서 발생하는 예외 상황을 처리하기 위한 전역 예외 핸들러 클래스입니다.
+ *
+ * @author Sijun Yang
+ */
+@ControllerAdvice
+public class RestExceptionHandlerAdvice {
+
+    /**
+     * 예상치 못한 예외 발생 시 처리하는 핸들러 메서드입니다. 500 Internal Server Error 응답을 반환합니다.
+     * @param ex 발생한 예외 객체
+     * @return 예외 정보를 담은 ProblemDetail 객체
+     */
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handleException(Exception ex) {
+        ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR,
+                ex.getLocalizedMessage());
+        response.setTitle("Un_Catched");
+        // TODO response.setType(URI.create());
+        return response;
+    }
+
+    /**
+     * {@link BadRequestException} 발생 시 처리하는 핸들러 메서드입니다. 400 Bad Request 응답을 반환합니다.
+     * @param ex 발생한 예외 객체
+     * @return 예외 정보를 담은 ProblemDetail 객체
+     */
+    @ExceptionHandler(BadRequestException.class)
+    public ProblemDetail handleException(BadRequestException ex) {
+        ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getLocalizedMessage());
+        response.setTitle(ex.getTitle());
+        // TODO response.setType(URI.create());
+        return response;
+    }
+
+    /**
+     * {@link ConflictException} 발생 시 처리하는 핸들러 메서드입니다. 409 Conflict 응답을 반환합니다.
+     * @param ex 발생한 예외 객체
+     * @return 예외 정보를 담은 ProblemDetail 객체
+     */
+    @ExceptionHandler(ConflictException.class)
+    public ProblemDetail handleException(ConflictException ex) {
+        ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getLocalizedMessage());
+        response.setTitle(ex.getTitle());
+        // TODO response.setType(URI.create());
+        return response;
+    }
+
+    /**
+     * {@link NotFoundException} 발생 시 처리하는 핸들러 메서드입니다. 404 Not Found 응답을 반환합니다.
+     * @param ex 발생한 예외 객체
+     * @return 예외 정보를 담은 ProblemDetail 객체
+     */
+    @ExceptionHandler(NotFoundException.class)
+    public ProblemDetail handleException(NotFoundException ex) {
+        ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getLocalizedMessage());
+        response.setTitle(ex.getTitle());
+        // TODO response.setType(URI.create());
+        return response;
+    }
+
+    /**
+     * {@link UnauthenticatedException} 발생 시 처리하는 핸들러 메서드입니다. 401 Unauthorized 응답을 반환합니다.
+     * @param ex 발생한 예외 객체
+     * @return 예외 정보를 담은 ProblemDetail 객체
+     */
+    @ExceptionHandler(UnauthenticatedException.class)
+    public ProblemDetail handleException(UnauthenticatedException ex) {
+        ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, ex.getLocalizedMessage());
+        response.setTitle(ex.getTitle());
+        // TODO response.setType(URI.create());
+        return response;
+    }
+
+    /**
+     * {@link ForbiddenException} 발생 시 처리하는 핸들러 메서드입니다. 403 Forbidden 응답을 반환합니다.
+     * @param ex 발생한 예외 객체
+     * @return 예외 정보를 담은 ProblemDetail 객체
+     */
+    @ExceptionHandler(ForbiddenException.class)
+    public ProblemDetail handleException(ForbiddenException ex) {
+        ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, ex.getLocalizedMessage());
+        response.setTitle(ex.getTitle());
+        // TODO response.setType(URI.create());
+        return response;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/api/error/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/api/error/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * celog 어플리케이션의 HTTP API 환경에서 발생하는 예외 상황을 처리하기 위한 기능을 지원합니다.
+ */
+package dev.sijunyang.celog.api.error;

--- a/src/main/java/dev/sijunyang/celog/core/global/error/BadRequestException.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/error/BadRequestException.java
@@ -1,0 +1,24 @@
+package dev.sijunyang.celog.core.global.error;
+
+/**
+ * {@link ExpectedException}를 상속하는 추상클래스입니다. 잘못된 입력 값이 사용되었을 때 사용합니다.
+ *
+ * @author Sijun Yang
+ * @see ExpectedException
+ */
+public abstract class BadRequestException extends ExpectedException {
+
+    protected BadRequestException(String message) {
+        super(message);
+    }
+
+    protected BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    protected BadRequestException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/error/ConflictException.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/error/ConflictException.java
@@ -1,0 +1,24 @@
+package dev.sijunyang.celog.core.global.error;
+
+/**
+ * {@link ExpectedException}를 상속하는 추상클래스입니다. 비지니스 로직상 불가능하거나 모순이 발생한 경우 사용합니다.
+ *
+ * @author Sijun Yang
+ * @see ExpectedException
+ */
+public abstract class ConflictException extends ExpectedException {
+
+    protected ConflictException(String message) {
+        super(message);
+    }
+
+    protected ConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    protected ConflictException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/error/ExpectedException.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/error/ExpectedException.java
@@ -1,0 +1,26 @@
+package dev.sijunyang.celog.core.global.error;
+
+/**
+ * 핵심 비즈니스 로직에서 의도된 예외 상황을 처리하기 위한 추상 클래스입니다. <br/>
+ * 이 클래스는 {@link TitleProvider} 인터페이스를 implement 합니다. 이 클래스를 상속받은 구체적인 예외 클래스들은 예외 발생 시
+ * 제목(title)을 제공해야 합니다.
+ *
+ * @author Sijun Yang
+ * @see TitleProvider
+ */
+abstract class ExpectedException extends RuntimeException implements TitleProvider {
+
+    protected ExpectedException(String message) {
+        super(message);
+    }
+
+    protected ExpectedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    protected ExpectedException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/error/ForbiddenException.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/error/ForbiddenException.java
@@ -1,0 +1,24 @@
+package dev.sijunyang.celog.core.global.error;
+
+/**
+ * {@link ExpectedException}를 상속하는 추상클래스입니다. 행동의 주체가 요청을 처리할 수 있는 권한이 없는 경우 사용합니다.
+ *
+ * @author Sijun Yang
+ * @see ExpectedException
+ */
+public abstract class ForbiddenException extends ExpectedException {
+
+    protected ForbiddenException(String message) {
+        super(message);
+    }
+
+    protected ForbiddenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    protected ForbiddenException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/error/NotFoundException.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/error/NotFoundException.java
@@ -1,0 +1,24 @@
+package dev.sijunyang.celog.core.global.error;
+
+/**
+ * {@link ExpectedException}를 상속하는 추상클래스입니다. 자원을 찾을 수 없는 경우 사용합니다.
+ *
+ * @author Sijun Yang
+ * @see ExpectedException
+ */
+public abstract class NotFoundException extends ExpectedException {
+
+    protected NotFoundException(String message) {
+        super(message);
+    }
+
+    protected NotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    protected NotFoundException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/error/TitleProvider.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/error/TitleProvider.java
@@ -1,0 +1,16 @@
+package dev.sijunyang.celog.core.global.error;
+
+/**
+ * 예외 발생 시 예외 타입을 식별할 수 있는 고유한 문자열을 반환하는 역할의 인터페이스입니다.
+ *
+ * @author Sijun Yang
+ */
+interface TitleProvider {
+
+    /**
+     * 예외 타입을 식별할 수 있는 고유한 문자열을 반환합니다.
+     * @return 예외 타입을 식별할 수 있는 고유한 문자열
+     */
+    String getTitle();
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/error/UnauthenticatedException.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/error/UnauthenticatedException.java
@@ -1,0 +1,24 @@
+package dev.sijunyang.celog.core.global.error;
+
+/**
+ * {@link ExpectedException}를 상속하는 추상클래스입니다. 행동의 주체를 식별할 수 없는 경우 사용합니다.
+ *
+ * @author Sijun Yang
+ * @see ExpectedException
+ */
+public abstract class UnauthenticatedException extends ExpectedException {
+
+    protected UnauthenticatedException(String message) {
+        super(message);
+    }
+
+    protected UnauthenticatedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    protected UnauthenticatedException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/global/error/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/error/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * celog 어플리케이션에서 발생할 수 있는 예외 상황을 처리하기 위한 예외 클래스와 유틸리티 클래스를 제공합니다.
+ */
+package dev.sijunyang.celog.core.global.error;


### PR DESCRIPTION
비즈니스 로직에서 발생하는 의도적인 예외를 처리하는 `ExpectedException`와 `ExpectedException`를 더 구체적인 의미로 나누는 자식 클래스를 구현하였습니다.
의도적인 예외란 어플리케이션이 해결할 수 없지만, 운영 중 자연스럽게 발생할 수 있는 예외 상황을 의미합니다.
주로 API 잘못된 호출로 인해서 발생합니다.

각 도메인 패키지에서 문맥에 맞게 `ExpectedException`의 자식 클래스를 상속하여 사용할 수 있습니다.

HTTP API 호출로 인해서 발생하는 `ExpectedException`의 자식 예외(클래스)들을 처리하는 전역 예외 핸들러 기능을 구현하였습니다.

Fixes #9 

