### PR TITLE
feat: Spring Security 환경 구성

### DIFF
--- a/src/main/java/dev/sijunyang/celog/api/AuthenticatedUserManager.java
+++ b/src/main/java/dev/sijunyang/celog/api/AuthenticatedUserManager.java
@@ -1,0 +1,24 @@
+package dev.sijunyang.celog.api;
+
+import dev.sijunyang.celog.core.global.enums.Role;
+
+/**
+ * 인증된 사용자의 ID와 역할(Role)을 제공하는 인터페이스입니다.
+ *
+ * @author Sijun Yang
+ */
+public interface AuthenticatedUserManager {
+
+    /**
+     * 인증된 사용자의 ID를 반환합니다.
+     * @return 사용자 ID
+     */
+    Long getId();
+
+    /**
+     * 인증된 사용자의 역할(Role)을 반환합니다.
+     * @return 사용자 역할
+     */
+    Role getRole();
+
+}

--- a/src/main/java/dev/sijunyang/celog/api/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/api/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 클라이언트와 통신하기 위한 API를 제공하는 패키지입니다.
+ */
+package dev.sijunyang.celog.api;

--- a/src/main/java/dev/sijunyang/celog/surpport/security/AuthenticatedUserManagerImpl.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/AuthenticatedUserManagerImpl.java
@@ -1,0 +1,33 @@
+package dev.sijunyang.celog.surpport.security;
+
+import dev.sijunyang.celog.api.AuthenticatedUserManager;
+import dev.sijunyang.celog.core.global.enums.Role;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+/**
+ * AuthenticatedUserManager 인터페이스를 구현한 클래스로, Spring Security에서 인증된 사용자 정보를 가져와서 제공합니다.
+ *
+ * @author Sijun Yang
+ */
+@Component
+public class AuthenticatedUserManagerImpl implements AuthenticatedUserManager {
+
+    @Override
+    public Long getId() {
+        // OAuth2 사용자의 이름(명)을 가져와 Long 타입으로 변환하여 반환합니다.
+        OAuth2User oAuth2User = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return Long.valueOf(oAuth2User.getName());
+    }
+
+    @Override
+    public Role getRole() {
+        // OAuth2 사용자의 "role" 속성 값을 가져와 Role 타입으로 반환합니다.
+        // 인증 된 사용자는 항상 "role" 속성 값을 가지고 있습니다.
+        OAuth2User oAuth2User = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return oAuth2User.getAttribute("role");
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/surpport/security/WebSecurityConfig.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/WebSecurityConfig.java
@@ -1,0 +1,24 @@
+package dev.sijunyang.celog.surpport.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            // HTML을 보내거나 받지 않으므로 csrf를 방지하지 않는다.
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests.anyRequest().permitAll());
+        return http.build();
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/surpport/security/package-info.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 인증/인가를 포한한 security 기능을 지원하는 패키지입니다.
+ */
+package dev.sijunyang.celog.surpport.security;


### PR DESCRIPTION
- Spring Security를 사용하기 위한 환경 구성
- 인증된 정보를 가져오기 위한 AuthenticatedUserManager 인터페이스와 그 구현체 구현
  - api 모듈과 support 모듈의 양방향 의존이 발생하지 않게 한다.

왜 AuthenticatedUserManager를 사용하는지는 제가 따로 정리한 [이 글](https://jun-develop.tistory.com/2)을 참고해주세요.

Closes #18 