### PR TITLE
fix: 누락되었던 OAuth2 환경 설정 추가

### DIFF
--- a/src/main/java/dev/sijunyang/celog/surpport/security/WebSecurityConfig.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package dev.sijunyang.celog.surpport.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -17,6 +18,7 @@ public class WebSecurityConfig {
             .httpBasic(AbstractHttpConfigurer::disable)
             // HTML을 보내거나 받지 않으므로 csrf를 방지하지 않는다.
             .csrf(AbstractHttpConfigurer::disable)
+            .oauth2Login(Customizer.withDefaults())
             .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests.anyRequest().permitAll());
         return http.build();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,13 @@
 spring:
   session:
     store-type: redis
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: ${github-client-id}
+            client-secret: ${github-client-secret}
+            redirect-uri: http://localhost:8080/login/oauth2/code/github
+  jpa:
+    generate-ddl: on


### PR DESCRIPTION
- Spring Security가 제공하는 OAuth2의 경우, 설정하지 않으면 적용되지 않습니다. 기본값을 사용하도록 설정을 추가하였습니다.
- properties 추가
  - github OAuth2 인증/인가를 사용할 수 있도록 github registration을 추가하였습니다.
  - 환경변수를 사용해서 private한 값을 노출되지 않게 하였습니다.