### PR TITLE
feat: springdoc Swagger 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.session:spring-session-data-redis'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
 spring:
   session:
     store-type: redis
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html


### PR DESCRIPTION
springdoc이 제공하는 Swagger 프레임워크를 도입합니다.

다음과 같은 이유로 도입하였습니다.
- 적용하기 쉽다.
- 제공하는 Swagger Web UI로 API 실행이 가능하다.
- 사용 자체는 코드에 비침투적으로 사용할 수 있다.

구체적인 설명을 포함하려는 경우, 코드에 침투적이라는 단점이 있습니다.

따라서 이후에 구체적인 설명을 작성해야 한다면, Spring Rest Docs로 대체하게 될 것 같습니다.