### PR TITLE
feat: 사용자 비즈니스 로직 구현

### DIFF
--- a/src/main/java/dev/sijunyang/celog/core/domain/user/CreateUserRequest.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/CreateUserRequest.java
@@ -1,0 +1,8 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import dev.sijunyang.celog.core.global.enums.AuthenticationType;
+import dev.sijunyang.celog.core.global.enums.Role;
+
+public record CreateUserRequest(String name, String email, OauthUser oauthUser, String profileUrl,
+        AuthenticationType authenticationType, Role role) {
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/CreateUserRequest.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/CreateUserRequest.java
@@ -2,7 +2,8 @@ package dev.sijunyang.celog.core.domain.user;
 
 import dev.sijunyang.celog.core.global.enums.AuthenticationType;
 import dev.sijunyang.celog.core.global.enums.Role;
+import jakarta.validation.constraints.NotNull;
 
-public record CreateUserRequest(String name, String email, OauthUser oauthUser, String profileUrl,
-        AuthenticationType authenticationType, Role role) {
+public record CreateUserRequest(@NotNull String name, String email, OauthUser oauthUser, String profileUrl,
+        @NotNull AuthenticationType authenticationType, @NotNull Role role) {
 }

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/DuplicatedEmailException.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/DuplicatedEmailException.java
@@ -1,0 +1,29 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import dev.sijunyang.celog.core.global.error.ConflictException;
+
+public class DuplicatedEmailException extends ConflictException {
+
+    public DuplicatedEmailException(String email) {
+        super(getMessage(email));
+    }
+
+    public DuplicatedEmailException(String email, Throwable cause) {
+        super(getMessage(email), cause);
+    }
+
+    public DuplicatedEmailException(String email, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(getMessage(email), cause, enableSuppression, writableStackTrace);
+    }
+
+    @Override
+    public String getTitle() {
+        return "Duplicated_Email";
+    }
+
+    private static String getMessage(String email) {
+        return "Duplicated email. input: " + email;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/OauthUser.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/OauthUser.java
@@ -3,16 +3,18 @@ package dev.sijunyang.celog.core.domain.user;
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 사용자의 OAuth 관련 정보를 저장하는 클래스입니다.
+ * 사용자의 OAuth 관련 정보를 저장하는 VO 클래스입니다.
  *
  * @author Sijun Yang
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
 @Embeddable
 public class OauthUser {
 

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UpdateUserRequest.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UpdateUserRequest.java
@@ -1,7 +1,8 @@
 package dev.sijunyang.celog.core.domain.user;
 
 import dev.sijunyang.celog.core.global.enums.Role;
+import jakarta.validation.constraints.NotNull;
 
-public record UpdateUserRequest(String name, String email, String profileUrl, Role role) {
+public record UpdateUserRequest(@NotNull String name, String email, String profileUrl, @NotNull Role role) {
 
 }

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UpdateUserRequest.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UpdateUserRequest.java
@@ -1,0 +1,7 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import dev.sijunyang.celog.core.global.enums.Role;
+
+public record UpdateUserRequest(String name, String email, String profileUrl, Role role) {
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserDto.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserDto.java
@@ -1,0 +1,45 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import java.time.LocalDateTime;
+
+import dev.sijunyang.celog.core.global.enums.AuthenticationType;
+import dev.sijunyang.celog.core.global.enums.Role;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserDto {
+
+    private final Long id;
+
+    private final String name;
+
+    private final String email;
+
+    private final OauthUser oauthUser;
+
+    private final String profileUrl;
+
+    private final AuthenticationType authenticationType;
+
+    private final Role role;
+
+    private final LocalDateTime modifiedAt;
+
+    private final LocalDateTime createdAt;
+
+    @Builder
+    public UserDto(Long id, String name, String email, OauthUser oauthUser, String profileUrl,
+            AuthenticationType authenticationType, Role role, LocalDateTime modifiedAt, LocalDateTime createdAt) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.profileUrl = profileUrl;
+        this.oauthUser = oauthUser;
+        this.authenticationType = authenticationType;
+        this.role = role;
+        this.modifiedAt = modifiedAt;
+        this.createdAt = createdAt;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
@@ -100,4 +100,18 @@ public class UserEntity extends BaseTimeEntity {
         return !(this.email == null && this.oauthUser == null);
     }
 
+    public UserDto toUserDto() {
+        return UserDto.builder()
+            .id(this.getId())
+            .name(this.getName())
+            .email(this.getEmail())
+            .profileUrl(this.getProfileUrl())
+            .oauthUser(this.getOauthUser())
+            .authenticationType(this.getAuthenticationType())
+            .role(this.getRole())
+            .modifiedAt(this.getModifiedAt())
+            .createdAt(this.getCreatedAt())
+            .build();
+    }
+
 }

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserNotFoundException.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserNotFoundException.java
@@ -1,0 +1,31 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import java.util.Map;
+
+import dev.sijunyang.celog.core.global.error.NotFoundException;
+
+public class UserNotFoundException extends NotFoundException {
+
+    public UserNotFoundException(Map<String, Object> inputs) {
+        super(getMessage(inputs));
+    }
+
+    public UserNotFoundException(Map<String, Object> inputs, Throwable cause) {
+        super(getMessage(inputs), cause);
+    }
+
+    public UserNotFoundException(Map<String, Object> inputs, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(getMessage(inputs), cause, enableSuppression, writableStackTrace);
+    }
+
+    @Override
+    public String getTitle() {
+        return "User_Not_Found";
+    }
+
+    private static String getMessage(Map<String, Object> inputs) {
+        return "User not found. inputs: " + inputs;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserRepository.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserRepository.java
@@ -1,5 +1,9 @@
 package dev.sijunyang.celog.core.domain.user;
 
+import java.util.Optional;
+
+import jakarta.validation.constraints.NotNull;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -8,5 +12,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @author Sijun Yang
  */
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+    boolean existsByEmail(String email);
+
+    Optional<UserEntity> findByEmail(@NotNull String email);
+
+    Optional<UserEntity> findByOauthUser_OauthProviderNameAndOauthUser_OauthUserId(@NotNull String oauthProviderName,
+            @NotNull String oauthUserId);
+
+    boolean existsByOauthUser_OauthProviderNameAndOauthUser_OauthUserId(@NotNull String oauthProviderName,
+            @NotNull String oauthUserId);
 
 }

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserRepository.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
  */
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
-    boolean existsByEmail(String email);
+    boolean existsByEmail(@NotNull String email);
 
     Optional<UserEntity> findByEmail(@NotNull String email);
 

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserRequestDeniedException.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserRequestDeniedException.java
@@ -1,0 +1,29 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import dev.sijunyang.celog.core.global.error.ForbiddenException;
+
+public class UserRequestDeniedException extends ForbiddenException {
+
+    public UserRequestDeniedException(long userId) {
+        super(getMessage(userId));
+    }
+
+    public UserRequestDeniedException(long userId, Throwable cause) {
+        super(getMessage(userId), cause);
+    }
+
+    public UserRequestDeniedException(long userId, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(getMessage(userId), cause, enableSuppression, writableStackTrace);
+    }
+
+    @Override
+    public String getTitle() {
+        return "User_Request_Denied";
+    }
+
+    private static String getMessage(long userId) {
+        return "Insufficient permissions. userId: " + userId;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,13 +12,10 @@ import org.springframework.validation.annotation.Validated;
 
 @Service
 @Validated
+@RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
-
-    public UserService(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
 
     /**
      * 새로운 사용자를 생성합니다.

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
@@ -67,8 +67,8 @@ public class UserService {
      */
     @Transactional
     public void deleteUser(long userId) {
-        UserEntity userEntity = findUserById(userId);
-        this.userRepository.delete(userEntity);
+        validUserById(userId);
+        this.userRepository.deleteById(userId);
     }
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
@@ -1,0 +1,154 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 새로운 사용자를 생성합니다.
+     * @param request 사용자 정보
+     */
+    @Transactional
+    public void createUser(CreateUserRequest request) {
+        validEmail(request.email());
+
+        UserEntity userEntity = UserEntity.builder()
+            .name(request.name())
+            .email(request.email())
+            .oauthUser(request.oauthUser())
+            .profileUrl(request.profileUrl())
+            .authenticationType(request.authenticationType())
+            .role(request.role())
+            .build();
+
+        this.userRepository.save(userEntity);
+    }
+
+    /**
+     * 기존 사용자 정보를 수정합니다.
+     * @param userId 수정할 사용자 ID
+     * @param request 수정된 사용자 정보
+     */
+    @Transactional
+    public void updateUser(Long userId, UpdateUserRequest request) {
+        validEmail(request.email());
+
+        UserEntity oldUserEntity = findUserById(userId);
+
+        UserEntity newEntity = UserEntity.builder()
+            .id(oldUserEntity.getId())
+            .name(request.name())
+            .email(request.email())
+            .oauthUser(oldUserEntity.getOauthUser())
+            .profileUrl(request.profileUrl())
+            .authenticationType(oldUserEntity.getAuthenticationType())
+            .role(request.role())
+            .build();
+
+        this.userRepository.save(newEntity);
+    }
+
+    /**
+     * 사용자를 삭제합니다.
+     * @param userId 삭제할 사용자 ID
+     */
+    @Transactional
+    public void deleteUser(Long userId) {
+        UserEntity userEntity = findUserById(userId);
+        this.userRepository.delete(userEntity);
+    }
+
+    /**
+     * 사용자 정보를 조회합니다.
+     * @param userId 조회할 사용자 ID
+     * @return 사용자 DTO
+     */
+    @Transactional(readOnly = true)
+    public UserDto getUserById(Long userId) {
+        return mapToUserDto(findUserById(userId));
+    }
+
+    /**
+     * 사용자 이메일로 사용자 정보를 조회합니다.
+     * @param email 조회할 사용자 이메일
+     * @return 사용자 DTO
+     */
+    @Transactional(readOnly = true)
+    public UserDto getUserByEmail(String email) {
+        return mapToUserDto(findUserById(email));
+    }
+
+    /**
+     * OAuth 정보로 사용자 정보를 조회합니다.
+     * @param providerName oauth 제공자 이름
+     * @param oauthUserId oauth 사용자 ID
+     * @return 사용자 DTO
+     */
+    @Transactional(readOnly = true)
+    public UserDto getUserByOAuthInfo(String providerName, String oauthUserId) {
+        return mapToUserDto(findUserByOAuthInfo(providerName, oauthUserId));
+    }
+
+    /**
+     * 사용자가 존재하는지 검사합니다.
+     * @param userId 조회할 사용자 ID
+     * @throws UserNotFoundException 사용자를 찾을 수 없는 경우
+     */
+    @Transactional(readOnly = true)
+    public void validUserById(Long userId) throws UserNotFoundException {
+        if (!existUserById(userId)) {
+            throw new UserNotFoundException(Map.of("userId", userId));
+        }
+    }
+
+    private UserEntity findUserById(Long userId) {
+        return this.userRepository.findById(userId)
+            .orElseThrow(() -> new UserNotFoundException(Map.of("userId", userId)));
+    }
+
+    private boolean existUserById(Long userId) {
+        return this.userRepository.existsById(userId);
+    }
+
+    public void validEmail(String email) throws UserNotFoundException {
+        if (this.userRepository.existsByEmail(email)) {
+            throw new DuplicatedEmailException(email);
+        }
+    }
+
+    private UserEntity findUserById(String email) {
+        return this.userRepository.findByEmail(email)
+            .orElseThrow(() -> new UserNotFoundException(Map.of("email", email)));
+    }
+
+    private UserEntity findUserByOAuthInfo(String providerName, String oauthUserId) {
+        return this.userRepository.findByOauthUser_OauthProviderNameAndOauthUser_OauthUserId(providerName, oauthUserId)
+            .orElseThrow(
+                    () -> new UserNotFoundException(Map.of("providerName", providerName, "oauthUserId", oauthUserId)));
+    }
+
+    public UserDto mapToUserDto(UserEntity user) {
+        return UserDto.builder()
+            .id(user.getId())
+            .name(user.getName())
+            .email(user.getEmail())
+            .profileUrl(user.getProfileUrl())
+            .oauthUser(user.getOauthUser())
+            .authenticationType(user.getAuthenticationType())
+            .role(user.getRole())
+            .modifiedAt(user.getModifiedAt())
+            .createdAt(user.getCreatedAt())
+            .build();
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
@@ -80,7 +80,7 @@ public class UserService {
      */
     @Transactional(readOnly = true)
     public UserDto getUserById(long userId) {
-        return mapToUserDto(findUserById(userId));
+        return findUserById(userId).toUserDto();
     }
 
     /**
@@ -90,7 +90,7 @@ public class UserService {
      */
     @Transactional(readOnly = true)
     public UserDto getUserByEmail(@NotNull String email) {
-        return mapToUserDto(findUserByEmail(email));
+        return findUserByEmail(email).toUserDto();
     }
 
     /**
@@ -101,7 +101,7 @@ public class UserService {
      */
     @Transactional(readOnly = true)
     public UserDto getUserByOAuthInfo(@NotNull String providerName, @NotNull String oauthUserId) {
-        return mapToUserDto(findUserByOAuthInfo(providerName, oauthUserId));
+        return findUserByOAuthInfo(providerName, oauthUserId).toUserDto();
     }
 
     /**
@@ -143,20 +143,6 @@ public class UserService {
         return this.userRepository.findByOauthUser_OauthProviderNameAndOauthUser_OauthUserId(providerName, oauthUserId)
             .orElseThrow(
                     () -> new UserNotFoundException(Map.of("providerName", providerName, "oauthUserId", oauthUserId)));
-    }
-
-    public UserDto mapToUserDto(@NotNull UserEntity user) {
-        return UserDto.builder()
-            .id(user.getId())
-            .name(user.getName())
-            .email(user.getEmail())
-            .profileUrl(user.getProfileUrl())
-            .oauthUser(user.getOauthUser())
-            .authenticationType(user.getAuthenticationType())
-            .role(user.getRole())
-            .modifiedAt(user.getModifiedAt())
-            .createdAt(user.getCreatedAt())
-            .build();
     }
 
 }

--- a/src/test/java/dev/sijunyang/celog/core/domain/user/OauthUserTest.java
+++ b/src/test/java/dev/sijunyang/celog/core/domain/user/OauthUserTest.java
@@ -1,0 +1,26 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OauthUserTest {
+
+    // VO로서 동작하는지 테스트
+    @Test
+    void testEqualsAndHashCode() {
+        OauthUser first = new OauthUser(new String("google"), new String("12345"));
+        OauthUser second = new OauthUser(new String("google"), new String("12345"));
+
+        // 각 객체/모든 필드가 서로 다른 메모리 위치에 정의되었는가?
+        assertNotEquals(System.identityHashCode(first), System.identityHashCode(second));
+        assertNotEquals(System.identityHashCode(first.getOauthUserId()),
+                System.identityHashCode(second.getOauthUserId()));
+        assertNotEquals(System.identityHashCode(first.getOauthProviderName()),
+                System.identityHashCode(second.getOauthProviderName()));
+
+        // 두 객체는 동일한가?
+        assertEquals(first, second);
+    }
+
+}

--- a/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
+++ b/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
@@ -100,15 +100,14 @@ class UserServiceTest {
     void shouldDeleteExistingUser() {
         // Given
         Long userId = 1L;
-        UserEntity existingUserEntity = UserEntity.builder().id(userId).build();
-
-        when(userRepository.findById(userId)).thenReturn(Optional.of(existingUserEntity));
+        when(userRepository.existsById(userId)).thenReturn(true);
 
         // When
         userService.deleteUser(userId);
 
         // Then
-        verify(userRepository, times(1)).delete(existingUserEntity);
+        verify(userRepository, times(1)).existsById(userId);
+        verify(userRepository, times(1)).deleteById(userId);
     }
 
     @Test

--- a/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
+++ b/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
@@ -51,6 +51,13 @@ class UserServiceTest {
         UserEntity savedUser = userRepository.save(any());
         assertNotNull(savedUser);
         assertEquals(userId, savedUser.getId());
+        assertEquals(createdUserEntity.getId(), savedUser.getId());
+        assertEquals(createdUserEntity.getName(), savedUser.getName());
+        assertEquals(createdUserEntity.getEmail(), savedUser.getEmail());
+        assertEquals(createdUserEntity.getOauthUser(), savedUser.getOauthUser());
+        assertEquals(createdUserEntity.getProfileUrl(), savedUser.getProfileUrl());
+        assertEquals(createdUserEntity.getAuthenticationType(), savedUser.getAuthenticationType());
+        assertEquals(createdUserEntity.getRole(), savedUser.getRole());
     }
 
     @Test

--- a/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
+++ b/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
@@ -30,7 +30,7 @@ class UserServiceTest {
     @Test
     void shouldCreateNewUser() {
         // Given
-        Long userId = 1L;
+        long userId = 1L;
         OauthUser oauthUser = new OauthUser("github", "12345678");
         CreateUserRequest request = new CreateUserRequest("John Doe", "john@example.com", oauthUser,
                 "https://profile/img-1234", AuthenticationType.OAUTH_GITHUB, Role.USER);
@@ -66,7 +66,8 @@ class UserServiceTest {
     @Test
     void shouldUpdateExistingUser() {
         // Given
-        Long userId = 1L;
+        long userId = 1L;
+        long requestUserId = 1L;
         UpdateUserRequest request = new UpdateUserRequest("John Smith", "john.smith@example.com", null, Role.ADMIN);
         UserEntity expectedUserEntity = UserEntity.builder()
             .id(userId)
@@ -81,11 +82,11 @@ class UserServiceTest {
         when(userRepository.findById(userId)).thenReturn(Optional.of(expectedUserEntity));
 
         // When
-        userService.updateUser(userId, request);
+        userService.updateUser(requestUserId, userId, request);
 
         // Then
         // 의존하는 Mock 객체가 올바르게 호출되었는가?
-        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(2)).findById(userId);
         verify(userRepository, times(1)).save(userEntityCaptor.capture());
 
         UserEntity capturedUserEntity = userEntityCaptor.getValue();
@@ -99,21 +100,24 @@ class UserServiceTest {
     @Test
     void shouldDeleteExistingUser() {
         // Given
-        Long userId = 1L;
-        when(userRepository.existsById(userId)).thenReturn(true);
+        long userId = 1L;
+        long requestUserId = 1L;
+        UserEntity expectedUserEntity = UserEntity.builder().id(userId).role(Role.USER).build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(expectedUserEntity));
 
         // When
-        userService.deleteUser(userId);
+        userService.deleteUser(requestUserId, userId);
 
         // Then
-        verify(userRepository, times(1)).existsById(userId);
+        verify(userRepository, times(1)).findById(userId);
         verify(userRepository, times(1)).deleteById(userId);
     }
 
     @Test
     void shouldReturnExistingUser() {
         // Given
-        Long userId = 1L;
+        long userId = 1L;
         UserEntity existingUserEntity = UserEntity.builder()
             .id(userId)
             .name("John Doe")
@@ -151,7 +155,7 @@ class UserServiceTest {
     @Test
     void shouldThrowUserNotFoundException() {
         // Given
-        Long userId = 1L;
+        long userId = 1L;
 
         doReturn(Optional.empty()).when(userRepository).findById(userId);
 

--- a/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
+++ b/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
@@ -1,0 +1,155 @@
+package dev.sijunyang.celog.core.domain.user;
+
+import dev.sijunyang.celog.core.global.enums.AuthenticationType;
+import dev.sijunyang.celog.core.global.enums.Role;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void shouldCreateNewUser() {
+        // Given
+        Long userId = 1L;
+        OauthUser oauthUser = new OauthUser("github", "12345678");
+        CreateUserRequest request = new CreateUserRequest("John Doe", "john@example.com", oauthUser,
+                "https://profile/img-1234", AuthenticationType.OAUTH_GITHUB, Role.USER);
+        UserEntity createdUserEntity = UserEntity.builder()
+            .id(userId)
+            .name("John Doe")
+            .email("john@example.com")
+            .oauthUser(oauthUser)
+            .profileUrl("https://profile/img-1234")
+            .authenticationType(AuthenticationType.OAUTH_GITHUB)
+            .role(Role.USER)
+            .build();
+
+        when(userRepository.save(any())).thenReturn(createdUserEntity);
+
+        // When
+        userService.createUser(request);
+
+        // Then
+        verify(userRepository, times(1)).existsByEmail(request.email());
+        verify(userRepository, times(1)).save(any());
+
+        UserEntity savedUser = userRepository.save(any());
+        assertNotNull(savedUser);
+        assertEquals(userId, savedUser.getId());
+    }
+
+    @Test
+    void shouldUpdateExistingUser() {
+        // Given
+        Long userId = 1L;
+        UpdateUserRequest request = new UpdateUserRequest("John Smith", "john.smith@example.com", null, Role.ADMIN);
+        UserEntity expectedUserEntity = UserEntity.builder()
+            .id(userId)
+            .name("John Smith")
+            .email("john.smith@example.com")
+            .oauthUser(null)
+            .profileUrl(null)
+            .authenticationType(AuthenticationType.EMAIL)
+            .role(Role.ADMIN)
+            .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(expectedUserEntity));
+
+        // When
+        userService.updateUser(userId, request);
+
+        // Then
+        // 의존하는 Mock 객체가 올바르게 호출되었는가?
+        verify(userRepository, times(1)).findById(userId);
+        assertEquals(expectedUserEntity.getId(), userId);
+        assertEquals(expectedUserEntity.getName(), request.name());
+        assertEquals(expectedUserEntity.getEmail(), request.email());
+        assertEquals(expectedUserEntity.getProfileUrl(), request.profileUrl());
+        assertEquals(expectedUserEntity.getRole(), request.role());
+
+        UserEntity updatedUser = userRepository.findById(userId).orElse(null);
+        assertNotNull(updatedUser);
+        assertEquals(request.name(), updatedUser.getName());
+        assertEquals(request.email(), updatedUser.getEmail());
+    }
+
+    @Test
+    void shouldDeleteExistingUser() {
+        // Given
+        Long userId = 1L;
+        UserEntity existingUserEntity = UserEntity.builder().id(userId).build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(existingUserEntity));
+
+        // When
+        userService.deleteUser(userId);
+
+        // Then
+        verify(userRepository, times(1)).delete(existingUserEntity);
+    }
+
+    @Test
+    void shouldReturnExistingUser() {
+        // Given
+        Long userId = 1L;
+        UserEntity existingUserEntity = UserEntity.builder()
+            .id(userId)
+            .name("John Doe")
+            .email("john@example.com")
+            .authenticationType(AuthenticationType.EMAIL)
+            .role(Role.USER)
+            .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(existingUserEntity));
+
+        // When
+        UserDto retrievedDto = userService.getUserById(userId);
+
+        // Then
+        assertNotNull(retrievedDto);
+        assertEquals(existingUserEntity.getId(), retrievedDto.getId());
+        assertEquals(existingUserEntity.getName(), retrievedDto.getName());
+        assertEquals(existingUserEntity.getEmail(), retrievedDto.getEmail());
+        assertEquals(existingUserEntity.getAuthenticationType(), retrievedDto.getAuthenticationType());
+        assertEquals(existingUserEntity.getRole(), retrievedDto.getRole());
+    }
+
+    @Test
+    void shouldThrowDuplicatedEmailException() {
+        // Given
+        CreateUserRequest request = new CreateUserRequest("John Doe", "john@example.com", null,
+                "https://profile/img-1234", AuthenticationType.OAUTH_GITHUB, Role.USER);
+
+        doReturn(true).when(userRepository).existsByEmail(request.email());
+
+        // When & Then
+        assertThrows(DuplicatedEmailException.class, () -> userService.createUser(request));
+    }
+
+    @Test
+    void shouldThrowUserNotFoundException() {
+        // Given
+        Long userId = 1L;
+
+        doReturn(Optional.empty()).when(userRepository).findById(userId);
+
+        // When & Then
+        assertThrows(UserNotFoundException.class, () -> userService.getUserById(userId));
+    }
+
+}

--- a/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
+++ b/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
@@ -47,10 +47,6 @@ class UserServiceTest {
         // Then
         verify(userRepository, times(1)).existsByEmail(request.email());
         verify(userRepository, times(1)).save(any());
-
-        UserEntity savedUser = userRepository.save(any());
-        assertNotNull(savedUser);
-        assertEquals(userId, savedUser.getId());
     }
 
     @Test
@@ -76,16 +72,6 @@ class UserServiceTest {
         // Then
         // 의존하는 Mock 객체가 올바르게 호출되었는가?
         verify(userRepository, times(1)).findById(userId);
-        assertEquals(expectedUserEntity.getId(), userId);
-        assertEquals(expectedUserEntity.getName(), request.name());
-        assertEquals(expectedUserEntity.getEmail(), request.email());
-        assertEquals(expectedUserEntity.getProfileUrl(), request.profileUrl());
-        assertEquals(expectedUserEntity.getRole(), request.role());
-
-        UserEntity updatedUser = userRepository.findById(userId).orElse(null);
-        assertNotNull(updatedUser);
-        assertEquals(request.name(), updatedUser.getName());
-        assertEquals(request.email(), updatedUser.getEmail());
     }
 
     @Test

--- a/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
+++ b/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
@@ -4,6 +4,8 @@ import dev.sijunyang.celog.core.global.enums.AuthenticationType;
 import dev.sijunyang.celog.core.global.enums.Role;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,6 +23,9 @@ class UserServiceTest {
 
     @InjectMocks
     private UserService userService;
+
+    @Captor
+    private ArgumentCaptor<UserEntity> userEntityCaptor;
 
     @Test
     void shouldCreateNewUser() {
@@ -46,7 +51,16 @@ class UserServiceTest {
 
         // Then
         verify(userRepository, times(1)).existsByEmail(request.email());
-        verify(userRepository, times(1)).save(any());
+        verify(userRepository, times(1)).save(userEntityCaptor.capture());
+
+        UserEntity capturedUserEntity = userEntityCaptor.getValue();
+
+        assertEquals(request.name(), capturedUserEntity.getName());
+        assertEquals(request.email(), capturedUserEntity.getEmail());
+        assertEquals(request.oauthUser(), capturedUserEntity.getOauthUser());
+        assertEquals(request.profileUrl(), capturedUserEntity.getProfileUrl());
+        assertEquals(request.authenticationType(), capturedUserEntity.getAuthenticationType());
+        assertEquals(request.role(), capturedUserEntity.getRole());
     }
 
     @Test
@@ -72,6 +86,14 @@ class UserServiceTest {
         // Then
         // 의존하는 Mock 객체가 올바르게 호출되었는가?
         verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).save(userEntityCaptor.capture());
+
+        UserEntity capturedUserEntity = userEntityCaptor.getValue();
+
+        assertEquals(request.name(), capturedUserEntity.getName());
+        assertEquals(request.email(), capturedUserEntity.getEmail());
+        assertEquals(request.profileUrl(), capturedUserEntity.getProfileUrl());
+        assertEquals(request.role(), capturedUserEntity.getRole());
     }
 
     @Test

--- a/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
+++ b/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
@@ -51,13 +51,6 @@ class UserServiceTest {
         UserEntity savedUser = userRepository.save(any());
         assertNotNull(savedUser);
         assertEquals(userId, savedUser.getId());
-        assertEquals(createdUserEntity.getId(), savedUser.getId());
-        assertEquals(createdUserEntity.getName(), savedUser.getName());
-        assertEquals(createdUserEntity.getEmail(), savedUser.getEmail());
-        assertEquals(createdUserEntity.getOauthUser(), savedUser.getOauthUser());
-        assertEquals(createdUserEntity.getProfileUrl(), savedUser.getProfileUrl());
-        assertEquals(createdUserEntity.getAuthenticationType(), savedUser.getAuthenticationType());
-        assertEquals(createdUserEntity.getRole(), savedUser.getRole());
     }
 
     @Test


### PR DESCRIPTION
사용자 비즈니스 로직을 구현하였습니다.

`@Validated`를 사용해서 유효성 검사를 수행합니다.

일반적이지 않은 Service, Repository 메서드가 있는데, 
OAuth2 인증에서 사용자를 식별하기 위해 `Email` 혹은 `OAuthUser`로 사용자를 찾는 기능이 필요하기 때문입니다.

그 외 코드 기능 설명은 CRUD 뿐이라 이해에 어려움이 없을 것 같아서 생략하겠습니다.

Closes #10 

### 피드백이 필요합니다.

서비스 객체를 구현하실 때, create나 update 기능의 경우 반환 타입을 무엇으로 하는게 좋은가요?
저는 수정 작업과 조회 작업이 분리되어야 직관적이고 생각해서, 조회를 위한 메서드 외에는 void를 사용해서 코드를 작성했습니다.

그런데 이 경우 테스트가 불가능한 것 같습니다.

지금 작성한 테스트코드에서 create나 update가 정상적으로 저장이 되었는지 확인할 수 있는 방법이 없네요. 
의존성있는 객체의 메서드가 몇 번 실행되었는지만 확인할 수 있고, 
서비스 코드에서 가공을 해서 원하는 결과와 다르게 저장이 되었더라도 테스트가 통과하네요.

어떻게 하는게 좋을까요?


