### PR TITLE
bulid: JaCoCo 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,20 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.4'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id 'checkstyle'
+    id 'jacoco'
     id 'io.spring.javaformat' version '0.0.41'
 }
 
 checkstyle {
     toolVersion = "9.3"
+}
+
+jacoco {
+    // JaCoCo 버전
+    toolVersion = "0.8.11"
+
+    // 테스트결과 리포트를 저장할 경로 변경
+    reportsDirectory = layout.buildDirectory.dir('jacocoReportDir')
 }
 
 group = 'dev.sijun-yang'
@@ -60,6 +69,26 @@ tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
 }
+
+jacocoTestReport {
+    dependsOn test // test task 가 성공해야만 실행된다.
+    reports {
+        html.required = true
+        xml.required = true
+        csv.required = false
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            // TODO rule, limit 추가하기.
+            limit {
+            }
+        }
+    }
+}
+
 
 // 커밋 컨벤션을 지키기 위한 commit-msg 스크립트를 local git hook에 적용하는 task
 // 새로운 환경에서 프로젝트를 열었을 때, commit-msg 스크립트를 적용하기 위해서 사용해야 함

--- a/src/test/java/dev/sijunyang/celog/CelogApplicationTests.java
+++ b/src/test/java/dev/sijunyang/celog/CelogApplicationTests.java
@@ -2,8 +2,9 @@ package dev.sijunyang.celog;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
 
-@SpringBootTest
+//@SpringBootTest 아직 통합테스트를 위한 외부 서비스(MySQL, Redis) 구성이 되지 않았음
 class CelogApplicationTests {
 
     @Test


### PR DESCRIPTION
테스트 커버리지 확인 및 CI 작업에 포함될 JaCoCo를 도입하였습니다.

아직 커버리지 Rule, Limit을 설정하지 않았습니다.

통합테스트용 환경을 구성하지 않아서, `CelogApplicationTests`가 계속 실패하고 있습니다.
임시로 `@SpringBootTest`를 주석처리하였습니다.

Closes #24 