### PR TITLE
fix: RestExceptionHandlerAdvice 500 status code 반환 시 예외메시지 노출 문제

### DIFF
--- a/src/main/java/dev/sijunyang/celog/api/error/RestExceptionHandlerAdvice.java
+++ b/src/main/java/dev/sijunyang/celog/api/error/RestExceptionHandlerAdvice.java
@@ -8,8 +8,8 @@ import dev.sijunyang.celog.core.global.error.UnauthenticatedException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 /**
@@ -17,7 +17,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
  *
  * @author Sijun Yang
  */
-@ControllerAdvice
+@RestControllerAdvice
 public class RestExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
 
     /**

--- a/src/main/java/dev/sijunyang/celog/api/error/RestExceptionHandlerAdvice.java
+++ b/src/main/java/dev/sijunyang/celog/api/error/RestExceptionHandlerAdvice.java
@@ -28,7 +28,7 @@ public class RestExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ProblemDetail handleException(Exception ex) {
         ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR,
-                ex.getLocalizedMessage());
+                "알수없는 문제가 발생하였습니다.");
         response.setTitle("Un_Catched");
         // TODO response.setType(URI.create());
         return response;


### PR DESCRIPTION
RestExceptionHandlerAdvice에서 예상하지 못한 예외를 전부 `handleException(Exception ex)` 메서드에서 catch합니다.
이 경우 500 status code를 반환하지만, 클라이언트에게 내부 정보(예외메시지)를 제공하고 있습니다.

예외메시지 대신 정해진 문자를 반환하도록 수정하였습니다.

또한, `@ControllerAdvice` 대신 `@RestControllerAdvice`를 사용합니다. 
스프링에서 제공하는 `ProblemDetail`를 사용해서인지 `@ControllerAdvice`를 사용해도 정상적으로 동작하는데, 
JSON으로 된 에러 메시지를 반환하므로 `@RestControllerAdvice`가 더 적절한 의미로 판단하였습니다.