### PR TITLE
feat: Github OAuth2 Login 기능 구현

### DIFF
--- a/src/main/java/dev/sijunyang/celog/core/domain/user/OAuth2Provider.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/OAuth2Provider.java
@@ -1,8 +1,7 @@
 package dev.sijunyang.celog.core.domain.user;
 
 /**
- * OAuth2 제공자 서비스의 이름을 관리하는 클래스입니다.
- * OAuth2에서 반환받는 제공자 서비스의 이름 Token 값과 동일한 문자열을 가지고 있습니다.
+ * OAuth2 제공자 서비스의 이름을 관리하는 클래스입니다. OAuth2에서 반환받는 제공자 서비스의 이름 Token 값과 동일한 문자열을 가지고 있습니다.
  *
  * @author Sijun Yang
  */
@@ -23,4 +22,3 @@ public final class OAuth2Provider {
     }
 
 }
-

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/OAuth2Provider.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/OAuth2Provider.java
@@ -1,13 +1,26 @@
 package dev.sijunyang.celog.core.domain.user;
 
+/**
+ * OAuth2 제공자 서비스의 이름을 관리하는 클래스입니다.
+ * OAuth2에서 반환받는 제공자 서비스의 이름 Token 값과 동일한 문자열을 가지고 있습니다.
+ *
+ * @author Sijun Yang
+ */
 public final class OAuth2Provider {
 
     /**
-     * OAuth 인증 기능을 제공하는 Github 서비스의 이름입니다.
+     * Github 서비스의 이름입니다.
      */
     public static final String GITHUB = "github";
 
+    /**
+     * Google 서비스의 이름입니다.
+     */
+    public static final String GOOGLE = "google";
+
     private OAuth2Provider() {
-    };
+        // 인스턴스 생성을 방지하기 위한 private 생성자
+    }
 
 }
+

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/OAuth2Provider.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/OAuth2Provider.java
@@ -1,0 +1,13 @@
+package dev.sijunyang.celog.core.domain.user;
+
+public final class OAuth2Provider {
+
+    /**
+     * OAuth 인증 기능을 제공하는 Github 서비스의 이름입니다.
+     */
+    public static final String GITHUB = "github";
+
+    private OAuth2Provider() {
+    };
+
+}

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserEntity.java
@@ -3,6 +3,8 @@ package dev.sijunyang.celog.core.domain.user;
 import dev.sijunyang.celog.core.global.enums.AuthenticationType;
 import dev.sijunyang.celog.core.global.enums.Role;
 import dev.sijunyang.celog.core.global.jpa.BaseTimeEntity;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -11,6 +13,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -28,6 +32,8 @@ import org.springframework.lang.Nullable;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "users") // user는 h2 예약어이므로 사용할 수 없음
+// 동일한 OAuth 사용자가 가입되지 않도록 복합 Unique 조건
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = { "oauth_provider_name", "oauth_user_id" }))
 public class UserEntity extends BaseTimeEntity {
 
     /**
@@ -55,6 +61,9 @@ public class UserEntity extends BaseTimeEntity {
      */
     @Nullable
     @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "oauthProviderName", column = @Column(name = "oauth_provider_name")),
+            @AttributeOverride(name = "oauthUserId", column = @Column(name = "oauth_user_id")) })
     private OauthUser oauthUser;
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 @Service
@@ -96,6 +95,15 @@ public class UserService {
     }
 
     /**
+     * 사용자 이메일로 사용자의 존재 여부를 확인합니다.
+     * @param email 조회할 사용자 이메일
+     * @return 사용자가 있으면 ture, 아니면 false
+     */
+    public boolean existUserByEmail(@NotNull String email) {
+        return this.userRepository.existsByEmail(email);
+    }
+
+    /**
      * OAuth 정보로 사용자 정보를 조회합니다.
      * @param providerName oauth 제공자 이름
      * @param oauthUserId oauth 사용자 ID
@@ -106,6 +114,17 @@ public class UserService {
             .orElseThrow(
                     () -> new UserNotFoundException(Map.of("providerName", providerName, "oauthUserId", oauthUserId)))
             .toUserDto();
+    }
+
+    /**
+     * 사용자 이메일로 사용자의 존재 여부를 확인합니다.
+     * @param providerName oauth 제공자 이름
+     * @param oauthUserId oauth 사용자 ID
+     * @return 사용자가 있으면 ture, 아니면 false
+     */
+    public boolean existUserByOAuthInfo(@NotNull String providerName, @NotNull String oauthUserId) {
+        return this.userRepository.existsByOauthUser_OauthProviderNameAndOauthUser_OauthUserId(providerName,
+                oauthUserId);
     }
 
     /**

--- a/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/user/UserService.java
@@ -95,7 +95,7 @@ public class UserService {
     }
 
     /**
-     * 사용자 이메일로 사용자의 존재 여부를 확인합니다.
+     * OAuth 정보로 사용자의 존재 여부를 확인합니다.
      * @param email 조회할 사용자 이메일
      * @return 사용자가 있으면 ture, 아니면 false
      */

--- a/src/main/java/dev/sijunyang/celog/core/global/enums/AuthenticationType.java
+++ b/src/main/java/dev/sijunyang/celog/core/global/enums/AuthenticationType.java
@@ -1,27 +1,36 @@
 package dev.sijunyang.celog.core.global.enums;
 
+import dev.sijunyang.celog.core.domain.user.OAuth2Provider;
 import dev.sijunyang.celog.core.domain.user.UserEntity;
+import lombok.Getter;
 
 /**
  * {@link UserEntity}의 인증 유형을 나타내는 Enum 클래스입니다.
  *
  * @author Sijun Yang
  */
+@Getter
 public enum AuthenticationType {
 
     /**
      * 이메일 인증 유형입니다.
      */
-    EMAIL,
+    EMAIL(null),
 
     /**
      * GitHub OAuth 인증 유형입니다.
      */
-    OAUTH_GITHUB,
+    OAUTH_GITHUB(OAuth2Provider.GITHUB),
 
     /**
      * Google OAuth 인증 유형입니다.
      */
-    OAUTH_GOOGLE;
+    OAUTH_GOOGLE(OAuth2Provider.GOOGLE);
+
+    private final String oauth2ProviderName;
+
+    AuthenticationType(String oauth2ProviderName) {
+        this.oauth2ProviderName = oauth2ProviderName;
+    }
 
 }

--- a/src/main/java/dev/sijunyang/celog/surpport/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package dev.sijunyang.celog.surpport.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+/**
+ * {@link AccessDeniedHandler}의 구현체로, {@link AccessDeniedException}을
+ * {@link HandlerExceptionResolver}에 위임하여 처리합니다. {@link HandlerExceptionResolver}는 기본적으로
+ * {@link SecurityExceptionHandlerAdvice}에서 예외를 해결합니다.
+ *
+ * @author Sijun Yang
+ * @see SecurityExceptionHandlerAdvice
+ */
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final HandlerExceptionResolver resolver;
+
+    public CustomAccessDeniedHandler(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+            AccessDeniedException accessDeniedException) {
+        this.resolver.resolveException(request, response, null, accessDeniedException);
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/surpport/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package dev.sijunyang.celog.surpport.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+/**
+ * {@link AuthenticationEntryPoint}의 구현체로, {@link AuthenticationException}을
+ * {@link HandlerExceptionResolver}에 위임하여 처리합니다. {@link HandlerExceptionResolver}는 기본적으로
+ * {@link SecurityExceptionHandlerAdvice}에서 예외를 해결합니다.
+ *
+ * @author Sijun Yang
+ * @see SecurityExceptionHandlerAdvice
+ */
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final HandlerExceptionResolver resolver;
+
+    public CustomAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authenticationException) {
+        this.resolver.resolveException(request, response, null, authenticationException);
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/surpport/security/CustomOauth2UserService.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/CustomOauth2UserService.java
@@ -12,6 +12,7 @@ import dev.sijunyang.celog.core.domain.user.UserDto;
 import dev.sijunyang.celog.core.domain.user.UserService;
 import dev.sijunyang.celog.core.global.enums.AuthenticationType;
 import dev.sijunyang.celog.core.global.enums.Role;
+import lombok.RequiredArgsConstructor;
 
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.GrantedAuthority;
@@ -25,6 +26,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private static final String ROLE_PREFIX = "ROLE_";
@@ -36,10 +38,6 @@ public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequ
     private final UserService userService;
 
     private final DefaultOAuth2UserService delegateOauth2UserService = new DefaultOAuth2UserService();
-
-    public CustomOauth2UserService(UserService userService) {
-        this.userService = userService;
-    }
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {

--- a/src/main/java/dev/sijunyang/celog/surpport/security/CustomOauth2UserService.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/CustomOauth2UserService.java
@@ -1,0 +1,117 @@
+package dev.sijunyang.celog.surpport.security;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.sijunyang.celog.core.domain.user.CreateUserRequest;
+import dev.sijunyang.celog.core.domain.user.OAuth2Provider;
+import dev.sijunyang.celog.core.domain.user.OauthUser;
+import dev.sijunyang.celog.core.domain.user.UserDto;
+import dev.sijunyang.celog.core.domain.user.UserService;
+import dev.sijunyang.celog.core.global.enums.AuthenticationType;
+import dev.sijunyang.celog.core.global.enums.Role;
+
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserService userService;
+
+    private final DefaultOAuth2UserService delegateOauth2UserService = new DefaultOAuth2UserService();
+
+    public CustomOauth2UserService(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = this.delegateOauth2UserService.loadUser(userRequest);
+        String providerName = userRequest.getClientRegistration().getRegistrationId();
+        UserDto createdUserDto = findOrCreateUserByProvider(providerName, oAuth2User);
+        return createAuthenticationToken(createdUserDto, oAuth2User);
+    }
+
+    private UserDto findOrCreateUserByProvider(String providerName, OAuth2User oAuth2User) {
+        OAuthUserInfo oAuthUserInfo = getOAuthUserInfo(providerName, oAuth2User);
+        if (oAuthUserInfo == null) {
+            throw new InternalAuthenticationServiceException("지원하지 않는 OAuth2 제공자: " + providerName);
+        }
+
+        String email = oAuthUserInfo.getEmail();
+        String oauthUserId = oAuth2User.getName();
+        UserDto userDto = getUserByEmailOrOAuthInfo(email, providerName, oauthUserId);
+
+        if (userDto == null) {
+            userDto = createUserByProvider(providerName, oAuthUserInfo);
+            if (userDto == null) {
+                throw new InternalAuthenticationServiceException(
+                        "OAuth2 인증 중, 새로 생성된 사용자를 가져오는데 문제가 발생했습니다. OAuth2User: " + oAuth2User);
+            }
+        }
+
+        return userDto;
+    }
+
+    private OAuthUserInfo getOAuthUserInfo(String providerName, OAuth2User oAuth2User) {
+        return switch (providerName) {
+            case OAuth2Provider.GITHUB -> new GithubOAuthUserInfo(oAuth2User);
+            default -> null;
+        };
+    }
+
+    private UserDto createUserByProvider(String providerName, OAuthUserInfo oAuthUserInfo) {
+        String oauthUserId = oAuthUserInfo.getName();
+        String name = oAuthUserInfo.getName();
+        String email = oAuthUserInfo.getEmail();
+        String avatarUrl = oAuthUserInfo.getProfileUrl();
+
+        OauthUser oauthUser = new OauthUser(providerName, oauthUserId);
+        CreateUserRequest createUserRequest = new CreateUserRequest(name, email, oauthUser, avatarUrl,
+                AuthenticationType.OAUTH_GITHUB, Role.USER);
+
+        this.userService.createUser(createUserRequest);
+
+        return getUserByEmailOrOAuthInfo(email, providerName, oauthUserId);
+    }
+
+    /**
+     * 이메일 또는 OAuth 정보로 사용자를 찾습니다. 기본적으로 이메일로 사용자를 식별하나, 이메일이 존재하지 않으면 OAuth 정보로 사용자를
+     * 찾습니다.
+     * @param email 사용자의 이메일 주소 (nullable)
+     * @param oAuthProviderName oAuth 제공사의 이름
+     * @param oauthUserId 사용자의 OAuth 고유 식별자
+     * @return 사용자 DTO 객체, 사용자를 찾지 못한 경우 null
+     */
+    private UserDto getUserByEmailOrOAuthInfo(String email, String oAuthProviderName, String oauthUserId) {
+        if (email != null && this.userService.existUserByEmail(email)) {
+            return this.userService.getUserByEmail(email);
+        }
+        else if (this.userService.existUserByOAuthInfo(oAuthProviderName, oauthUserId)) {
+            return this.userService.getUserByOAuthInfo(oAuthProviderName, oauthUserId);
+        }
+        return null;
+    }
+
+    private OAuth2User createAuthenticationToken(UserDto userDto, OAuth2User oAuth2User) {
+        Role role = userDto.getRole();
+        String nameAttributeKey = "celog_user_id";
+        Map<String, Object> attributes = new HashMap<>(Map.of("celog_user_id", userDto.getId(), "celog_role", role));
+        attributes.putAll(oAuth2User.getAttributes());
+        Collection<GrantedAuthority> authorities = new ArrayList<>(oAuth2User.getAuthorities());
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + role.name()));
+        return new DefaultOAuth2User(authorities, attributes, nameAttributeKey);
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/surpport/security/CustomOauth2UserService.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/CustomOauth2UserService.java
@@ -17,15 +17,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.stereotype.Service;
 
-@Service
 @RequiredArgsConstructor
 public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
@@ -37,7 +34,7 @@ public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     private final UserService userService;
 
-    private final DefaultOAuth2UserService delegateOauth2UserService = new DefaultOAuth2UserService();
+    private final OAuth2UserService<OAuth2UserRequest, OAuth2User> delegateOauth2UserService;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {

--- a/src/main/java/dev/sijunyang/celog/surpport/security/GithubOAuthUserInfo.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/GithubOAuthUserInfo.java
@@ -1,14 +1,14 @@
 package dev.sijunyang.celog.surpport.security;
 
+import dev.sijunyang.celog.core.global.enums.AuthenticationType;
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+@RequiredArgsConstructor
 public class GithubOAuthUserInfo implements OAuthUserInfo {
 
     private final OAuth2User oAuth2User;
-
-    public GithubOAuthUserInfo(OAuth2User oAuth2User) {
-        this.oAuth2User = oAuth2User;
-    }
 
     @Override
     public String getEmail() {
@@ -23,6 +23,11 @@ public class GithubOAuthUserInfo implements OAuthUserInfo {
     @Override
     public String getProfileUrl() {
         return this.oAuth2User.getAttribute("avatar_url");
+    }
+
+    @Override
+    public AuthenticationType getAuthenticationType() {
+        return AuthenticationType.OAUTH_GITHUB;
     }
 
 }

--- a/src/main/java/dev/sijunyang/celog/surpport/security/GithubOAuthUserInfo.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/GithubOAuthUserInfo.java
@@ -1,0 +1,28 @@
+package dev.sijunyang.celog.surpport.security;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public class GithubOAuthUserInfo implements OAuthUserInfo {
+
+    private final OAuth2User oAuth2User;
+
+    public GithubOAuthUserInfo(OAuth2User oAuth2User) {
+        this.oAuth2User = oAuth2User;
+    }
+
+    @Override
+    public String getEmail() {
+        return this.oAuth2User.getAttribute("email");
+    }
+
+    @Override
+    public String getName() {
+        return this.oAuth2User.getAttribute("name");
+    }
+
+    @Override
+    public String getProfileUrl() {
+        return this.oAuth2User.getAttribute("avatar_url");
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/surpport/security/OAuth2Config.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/OAuth2Config.java
@@ -1,0 +1,21 @@
+package dev.sijunyang.celog.surpport.security;
+
+import dev.sijunyang.celog.core.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+
+@Configuration
+@RequiredArgsConstructor
+public class OAuth2Config {
+
+    private final UserService userService;
+
+    @Bean
+    public CustomOauth2UserService customOauth2UserService() {
+        return new CustomOauth2UserService(this.userService, new DefaultOAuth2UserService());
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/surpport/security/OAuthUserInfo.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/OAuthUserInfo.java
@@ -1,0 +1,11 @@
+package dev.sijunyang.celog.surpport.security;
+
+public interface OAuthUserInfo {
+
+    String getEmail();
+
+    String getName();
+
+    String getProfileUrl();
+
+}

--- a/src/main/java/dev/sijunyang/celog/surpport/security/OAuthUserInfo.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/OAuthUserInfo.java
@@ -1,5 +1,7 @@
 package dev.sijunyang.celog.surpport.security;
 
+import dev.sijunyang.celog.core.global.enums.AuthenticationType;
+
 public interface OAuthUserInfo {
 
     String getEmail();
@@ -7,5 +9,7 @@ public interface OAuthUserInfo {
     String getName();
 
     String getProfileUrl();
+
+    AuthenticationType getAuthenticationType();
 
 }

--- a/src/main/java/dev/sijunyang/celog/surpport/security/SecurityExceptionHandlerAdvice.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/SecurityExceptionHandlerAdvice.java
@@ -7,7 +7,6 @@ import org.springframework.security.authentication.InternalAuthenticationService
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 /**
  * Spring Security FilterChain에서 발생하는 예외를 처리하기 위한 클래스입니다. 다른 웹 예외와 동일한 방식으로 관리하기 위해 사용합니다.
@@ -23,7 +22,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 // 이 객체가 예외처리하는 예외들은 인증/보안과 관련된 기능들이므로 의도하고 던지는 구체적인 예외가 아닌 이상,
 // 클라이언트에게 정보를 노출하지 않아야 한다.
 @RestControllerAdvice
-public class SecurityExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
+public class SecurityExceptionHandlerAdvice {
 
     @ExceptionHandler(RuntimeException.class)
     public ProblemDetail handleException(RuntimeException ex) {

--- a/src/main/java/dev/sijunyang/celog/surpport/security/SecurityExceptionHandlerAdvice.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/SecurityExceptionHandlerAdvice.java
@@ -3,6 +3,7 @@ package dev.sijunyang.celog.surpport.security;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -36,6 +37,14 @@ public class SecurityExceptionHandlerAdvice {
     public ProblemDetail handleException(InternalAuthenticationServiceException ex) {
         ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR,
                 "인증 중 서버 내부적인 문제가 발생하였습니다.");
+        response.setTitle("Authentication_Service_Exception");
+        return response;
+    }
+
+    @ExceptionHandler(AuthenticationServiceException.class)
+    public ProblemDetail handleException(AuthenticationServiceException ex) {
+        ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.SERVICE_UNAVAILABLE,
+                "인증 중 서버 외부적인 문제가 발생하였습니다.");
         response.setTitle("Authentication_Service_Exception");
         return response;
     }

--- a/src/main/java/dev/sijunyang/celog/surpport/security/SecurityExceptionHandlerAdvice.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/SecurityExceptionHandlerAdvice.java
@@ -1,0 +1,58 @@
+package dev.sijunyang.celog.surpport.security;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+/**
+ * Spring Security FilterChain에서 발생하는 예외를 처리하기 위한 클래스입니다. 다른 웹 예외와 동일한 방식으로 관리하기 위해 사용합니다.
+ * <br/>
+ * Security FilterChain은 스프링 컨테이너 바깥에서 실행되므로 DispatcherServlet에서 예외를 직접 처리할 수 없습니다. 그러나
+ * {@link CustomAccessDeniedHandler}, {@link CustomAuthenticationEntryPoint}에서 예외를 이
+ * 클래스의 @ExceptionHandler가 처리하도록 위임합니다.
+ *
+ * @author Sijun Yang
+ * @see CustomAccessDeniedHandler
+ * @see CustomAuthenticationEntryPoint
+ */
+// 이 객체가 예외처리하는 예외들은 인증/보안과 관련된 기능들이므로 의도하고 던지는 구체적인 예외가 아닌 이상,
+// 클라이언트에게 정보를 노출하지 않아야 한다.
+@RestControllerAdvice
+public class SecurityExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ProblemDetail handleException(RuntimeException ex) {
+        ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR,
+                "알수없는 문제가 발생하였습니다.");
+        response.setTitle("Authentication_Unexpected_Error");
+        return response;
+    }
+
+    @ExceptionHandler(InternalAuthenticationServiceException.class)
+    public ProblemDetail handleException(InternalAuthenticationServiceException ex) {
+        ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR,
+                "인증 중 서버 내부적인 문제가 발생하였습니다.");
+        response.setTitle("Authentication_Service_Exception");
+        return response;
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ProblemDetail handleException(AuthenticationException ex) {
+        ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "사용자를 식별할 수 없습니다.");
+        response.setTitle("Authentication_Exception");
+        return response;
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ProblemDetail handleException(AccessDeniedException ex) {
+        ProblemDetail response = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, "사용자의 권한이 올바르지 않습니다.");
+        response.setTitle("Access_Denied_Exception");
+        return response;
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/surpport/security/WebSecurityConfig.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/WebSecurityConfig.java
@@ -1,16 +1,25 @@
 package dev.sijunyang.celog.surpport.security;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSecurity
 public class WebSecurityConfig {
+
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+
+    private final AccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -19,6 +28,8 @@ public class WebSecurityConfig {
             // HTML을 보내거나 받지 않으므로 csrf를 방지하지 않는다.
             .csrf(AbstractHttpConfigurer::disable)
             .oauth2Login(Customizer.withDefaults())
+            .exceptionHandling((configurer) -> configurer.accessDeniedHandler(this.accessDeniedHandler)
+                .authenticationEntryPoint(this.authenticationEntryPoint))
             .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests.anyRequest().permitAll());
         return http.build();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,9 @@ spring:
             client-secret: ${github-client-secret}
             redirect-uri: http://localhost:8080/login/oauth2/code/github
   jpa:
-    generate-ddl: on
+    hibernate:
+      ddl-auto: update
+    show-sql: true
 springdoc:
   swagger-ui:
     path: /swagger-ui.html

--- a/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
+++ b/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
@@ -165,7 +165,8 @@ class UserServiceTest {
         // Given
         String providerName = "google";
         String oauthUserId = "1234567890";
-        when(userRepository.existsByOauthUser_OauthProviderNameAndOauthUser_OauthUserId(providerName, oauthUserId)).thenReturn(true);
+        when(userRepository.existsByOauthUser_OauthProviderNameAndOauthUser_OauthUserId(providerName, oauthUserId))
+            .thenReturn(true);
 
         // When & Then
         assertTrue(userService.existUserByOAuthInfo(providerName, oauthUserId));
@@ -176,7 +177,8 @@ class UserServiceTest {
         // Given
         String providerName = "google";
         String oauthUserId = "1234567890";
-        when(userRepository.existsByOauthUser_OauthProviderNameAndOauthUser_OauthUserId(providerName, oauthUserId)).thenReturn(false);
+        when(userRepository.existsByOauthUser_OauthProviderNameAndOauthUser_OauthUserId(providerName, oauthUserId))
+            .thenReturn(false);
 
         // When & Then
         assertFalse(userService.existUserByOAuthInfo(providerName, oauthUserId));

--- a/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
+++ b/src/test/java/dev/sijunyang/celog/core/domain/user/UserServiceTest.java
@@ -141,6 +141,48 @@ class UserServiceTest {
     }
 
     @Test
+    void existUserByEmail_ShouldReturnTrueWhenUserExists() {
+        // Given
+        String email = "test@example.com";
+        when(userRepository.existsByEmail(email)).thenReturn(true);
+
+        // When & Then
+        assertTrue(userService.existUserByEmail(email));
+    }
+
+    @Test
+    void existUserByEmail_ShouldReturnFalseWhenUserDoesNot() {
+        // Given
+        String email = "test@example.com";
+        when(userRepository.existsByEmail(email)).thenReturn(false);
+
+        // When & Then
+        assertFalse(userService.existUserByEmail(email));
+    }
+
+    @Test
+    void existUserByOAuthInfo_ShouldReturnTrueWhenUserExists() {
+        // Given
+        String providerName = "google";
+        String oauthUserId = "1234567890";
+        when(userRepository.existsByOauthUser_OauthProviderNameAndOauthUser_OauthUserId(providerName, oauthUserId)).thenReturn(true);
+
+        // When & Then
+        assertTrue(userService.existUserByOAuthInfo(providerName, oauthUserId));
+    }
+
+    @Test
+    void existUserByOAuthInfo_ShouldReturnFalseWhenUserDoesNotExist() {
+        // Given
+        String providerName = "google";
+        String oauthUserId = "1234567890";
+        when(userRepository.existsByOauthUser_OauthProviderNameAndOauthUser_OauthUserId(providerName, oauthUserId)).thenReturn(false);
+
+        // When & Then
+        assertFalse(userService.existUserByOAuthInfo(providerName, oauthUserId));
+    }
+
+    @Test
     void shouldThrowDuplicatedEmailException() {
         // Given
         CreateUserRequest request = new CreateUserRequest("John Doe", "john@example.com", null,

--- a/src/test/java/dev/sijunyang/celog/surpport/security/CustomOauth2UserServiceTest.java
+++ b/src/test/java/dev/sijunyang/celog/surpport/security/CustomOauth2UserServiceTest.java
@@ -1,0 +1,93 @@
+package dev.sijunyang.celog.surpport.security;
+
+import java.util.Collections;
+import java.util.Map;
+
+import dev.sijunyang.celog.core.domain.user.UserDto;
+import dev.sijunyang.celog.core.domain.user.UserService;
+import dev.sijunyang.celog.core.global.enums.Role;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CustomOauth2UserServiceTest {
+
+    @Mock
+    private OAuth2UserRequest oAuth2UserRequest;
+
+    @Mock
+    private ClientRegistration clientRegistration;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private DefaultOAuth2UserService delegateOauth2UserService;
+
+    @InjectMocks
+    private CustomOauth2UserService customOauth2UserService;
+
+    @Test
+    void shouldCreateNewOAuthUser() {
+        // Given
+        OAuth2User willReturnOAuth2User = new DefaultOAuth2User(Collections.emptySet(), Map.of("avatar_url",
+                "https:img-url.com/1234", "id", 12345678, "name", "UserName1", "email", "userEmail@gmail.com"), "id");
+
+        when(oAuth2UserRequest.getClientRegistration()).thenReturn(clientRegistration);
+        when(clientRegistration.getRegistrationId()).thenReturn("github");
+        when(delegateOauth2UserService.loadUser(oAuth2UserRequest)).thenReturn(willReturnOAuth2User);
+        when(userService.existUserByEmail("userEmail@gmail.com")).thenReturn(false);
+        when(userService.existUserByEmail("userEmail@gmail.com")).thenReturn(true);
+        when(userService.getUserByEmail("userEmail@gmail.com"))
+            .thenReturn(UserDto.builder().id(1L).role(Role.USER).build());
+
+        // When
+        OAuth2User rt = customOauth2UserService.loadUser(oAuth2UserRequest);
+
+        // Then
+        Assertions.assertEquals(rt.getAttribute("avatar_url"), "https:img-url.com/1234");
+        Assertions.assertEquals(rt.getName(), "1");
+        Assertions.assertEquals((Integer) rt.getAttribute("id"), 12345678);
+        Assertions.assertEquals(rt.getAttribute("name"), "UserName1");
+        Assertions.assertEquals(rt.getAttribute("email"), "userEmail@gmail.com");
+        Assertions.assertEquals(rt.getAttribute("celog_role"), Role.USER);
+
+    }
+
+    @Test
+    void shouldThrowExWhenUnSupportOAuth2Provider() {
+        // Given
+        when(oAuth2UserRequest.getClientRegistration()).thenReturn(clientRegistration);
+        when(clientRegistration.getRegistrationId()).thenReturn("unSupportOAuth2Provider");
+
+        // When & Then
+        Assertions.assertThrows(InternalAuthenticationServiceException.class, () -> customOauth2UserService.loadUser(oAuth2UserRequest));
+
+    }
+
+    // @Test
+    // void shouldGetOAuthUser() {
+    // // Given
+    // Mockito.when(userService.)
+    //
+    // // When
+    // OAuth2User rt = customOauth2UserService.loadUser(dummyOAuth2UserRequest);
+    //
+    // // Then
+    //
+    //
+    // }
+
+}


### PR DESCRIPTION
`CustomOauth2UserService`는 Spring Security가 제공하는 OAuth2 기능을 사용해서 OAuth2 인증 이후 로그인/회원가입을 진행합니다.

`CustomAuthenticationEntryPoint`, `CustomAccessDeniedHandler`는 예외를 받아 `HandlerExceptionResolver `로 위임합니다. 
`SecurityExceptionHandlerAdvice`에서 인증/인가 중 발생하는 Spring Security 예외를 처리합니다.

Closes #23 

#### 궁금한 점

테스트코드를 작성하다가 `should~`로 하면 이름이 겹치게 되서 `메서드이름_should`로 테스트코드 메서드 이름을 사용했습니다. 
e.g. `existUserByOAuthInfo_ShouldReturnTrueWhenUserExists`
이름이 너무 길어지는 것 같은데, 실무에선 어떤 식으로 테스트코드 이름을 사용하나요? 실무에서도 여러 경우가 있을 것 같은데, 어떤 식으로 사용하는지 궁금합니다.
