### PR TITLE
fix: 빈 순환참조, 변수 명 잘못된 문제 & feat: redis 세션 비활성화

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
       - 'MYSQL_USER=myuser'
     ports:
       - '3306:3306' # 외부에서 값을 확인하기 위해서 포트포워딩
-  redis:
-    image: 'redis:7.2'
-    ports:
-      - '6379:6379' # 외부에서 값을 확인하기 위해서 포트포워딩
+#  redis:
+#    image: 'redis:7.2'
+#    ports:
+#      - '6379:6379' # 외부에서 값을 확인하기 위해서 포트포워딩

--- a/src/main/java/dev/sijunyang/celog/core/domain/reply/ReplyService.java
+++ b/src/main/java/dev/sijunyang/celog/core/domain/reply/ReplyService.java
@@ -12,14 +12,13 @@ import dev.sijunyang.celog.core.global.error.nextVer.InsufficientPermissionExcep
 import dev.sijunyang.celog.core.global.error.nextVer.ResourceNotFoundException;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import lombok.RequiredArgsConstructor;
 
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
 @Service
 @Validated
-@RequiredArgsConstructor
 public class ReplyService {
 
     private final ReplyRepository replyRepository;
@@ -27,6 +26,12 @@ public class ReplyService {
     private final PostService postService;
 
     private final UserService userService;
+
+    public ReplyService(ReplyRepository replyRepository, @Lazy PostService postService, UserService userService) {
+        this.replyRepository = replyRepository;
+        this.postService = postService;
+        this.userService = userService;
+    }
 
     /**
      * 새로운 댓글을 생성합니다. 댓글을 생성하려는 게시글에 접근 가능해야 합니다.

--- a/src/main/java/dev/sijunyang/celog/surpport/ncp/ImageUploadServiceImpl.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/ncp/ImageUploadServiceImpl.java
@@ -70,7 +70,7 @@ public class ImageUploadServiceImpl implements ImageUploadService {
     }
 
     private boolean isSupportedFileExtension(String fileExtension) {
-        return supportExtensions.stream()
+        return supportedExtensions.stream()
             .anyMatch((supportExtension) -> Objects.equals(supportExtension, fileExtension));
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,8 @@ spring:
   servlet:
     multipart:
       max-file-size: 1MB
-  session:
-    store-type: redis
+#  session:
+#    store-type: redis
   security:
     oauth2:
       client:


### PR DESCRIPTION
빈 순환참조는 지금 당장은 `@lazy`를 사용해 해결하였습니다.

지금 계발 계획 상 여러 인스턴스(스케일아웃)을 고려하진 않을 것 같아서, redis 세션을 사용하지 않도록 변경하였습니다.