### PR TITLE
CD 구현하기

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,53 @@
+name: celog CD
+
+on:
+  push:
+    branches: [ "*" ] # CD 테스트 용으로 "main"
+
+jobs:
+  push_to_registry:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew jib \                                                                                                                                                                           INT ✘  7m 42s   22:59:11 
+          -Djib.to.image=${{ secrets.NCP_CONTAINER_IMAGE }} \
+          -Djib.to.auth.username=${{ secrets.NCP_ACCESS_KEY }} \
+          -Djib.to.auth.password=${{ secrets.NCP_SECRET_KEY }}
+
+  pull_from_registry:
+    needs: push_to_registry # 순서 설정
+    runs-on: ubuntu-latest
+    steps:
+      - name: connect ssh
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.PROD_USERNAME }}
+          password: ${{ secrets.PROD_PASSWORD }}
+          port: ${{ secrets.PROD_PORT }}
+          script: | 
+            touch ./.env.prod
+            echo "${{ secrets.ENV_CONFIG }}" > ./.env.prod
+            docker pull ${{ secrets.NCP_CONTAINER_IMAGE }}:latest
+            docker stop $(docker ps -a -q)
+            docker rm $(docker ps -a -q)
+            docker run -d -p 8080:8080 -p 3306:3306 --env-file ./.env.prod ${{ secrets.NCP_CONTAINER_IMAGE }}:latest
+            docker image prune -f
+          # 환경변수 설정
+          # 새로운 어플리케이션 이미지 받기
+          # 기존 모든 컨테이너 동작 중지 & 종료
+          # 새로운 어플리케이션 컨테이너로 실행하기 - 사용한 환경변수 적용
+          # 사용하지 않는 이미지 전부 제거

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,10 +23,10 @@ jobs:
 
       - name: Build with Gradle Wrapper
         run: | 
-          ./gradlew jib 
-          -Djib.to.image=${{ secrets.NCP_CONTAINER_IMAGE }}
-          -Djib.to.auth.username=${{ secrets.NCP_ACCESS_KEY }}
-          -Djib.to.auth.password=${{ secrets.NCP_SECRET_KEY }}
+          ./gradlew jib \
+          -Djib.to.image=${{ secrets.NCP_CONTAINER_IMAGE }} \
+          -Djib.to.auth.username=${{ secrets.NCP_ACCESS_KEY }} \
+          -Djib.to.auth.password=${{ secrets.NCP_SECRET_KEY }} \
 
   pull_from_registry:
     needs: push_to_registry # 순서 설정

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: celog CD
 
 on:
   push:
-    branches: [ "*" ] # CD 테스트 용으로 "main"
+    branches: [ "*" ] # CD 테스트 용으로 "main" 
 
 jobs:
   push_to_registry:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: celog CD
 
 on:
   push:
-    branches: [ "*" ] # CD 테스트 용으로 "main" 
+    branches: [ "main" ]
 
 jobs:
   push_to_registry:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,9 +22,10 @@ jobs:
         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5
 
       - name: Build with Gradle Wrapper
-        run: ./gradlew jib \                                                                                                                                                                           INT ✘  7m 42s   22:59:11 
-          -Djib.to.image=${{ secrets.NCP_CONTAINER_IMAGE }} \
-          -Djib.to.auth.username=${{ secrets.NCP_ACCESS_KEY }} \
+        run: | 
+          ./gradlew jib 
+          -Djib.to.image=${{ secrets.NCP_CONTAINER_IMAGE }}
+          -Djib.to.auth.username=${{ secrets.NCP_ACCESS_KEY }}
           -Djib.to.auth.password=${{ secrets.NCP_SECRET_KEY }}
 
   pull_from_registry:

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.time.LocalDateTime
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.3'
@@ -6,6 +8,7 @@ plugins {
     id 'checkstyle'
     id 'jacoco'
     id 'io.spring.javaformat' version '0.0.41'
+    id 'com.google.cloud.tools.jib' version "3.4.2"
 }
 
 checkstyle {
@@ -19,9 +22,6 @@ jacoco {
     // 테스트결과 리포트를 저장할 경로 변경
     reportsDirectory = layout.buildDirectory.dir('jacocoReportDir')
 }
-
-group = 'dev.sijun-yang'
-version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '17'
@@ -99,6 +99,48 @@ jacocoTestReport {
 //        }
 //    }
 //}
+
+group = 'dev.sijun-yang'
+// 따로 버전 관리는 안함, 도커로 빌드해서 사용하고 시간 기준으로 알아서 관리
+//version = '0.0.1-SNAPSHOT'
+
+jib {
+    from {
+        // openjdk 이미지는 더 이상 관리 되지 않으므로 amazoncorretto를 사용
+        image = 'amazoncorretto:17-alpine-jdk'
+        platforms {
+            platform {
+                architecture = 'amd64'
+                os = 'linux'
+            }
+            platform {
+                architecture = 'arm64'
+                os = 'linux'
+            }
+        }
+
+        to {
+            // 주소 뒤에 사용할 이미지 이름을 작성해야 동작한다. 이름 자체는 뭘 하든 상관 없다.
+            // ex: image = '<name>.kr.ncr.ntruss.com/<이미지 이름>'
+            /*
+            image registry 위치는 system properties를 사용해서 CD 스크립트에서 주입해 줄 예정
+            참고: https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin#system-properties
+             */
+            // version과 tags에 작성한 tags 로 이미지를 배포. 예시: celog-server:v_20240412113205, celog-server:latest
+            version = 'latest'
+            tags = ['v_' + LocalDateTime.now().format("yyyyMMddhhmmss")]
+            auth {
+                // username & password 도 마찬가지로 CD 스크립트에서 주입
+            }
+        }
+        container {
+            // 컨테이너 실행 시, run -e SPRING_ACTIVE_PROFILE=OOO 처럼 사용해서 profile 주입 가능
+            jvmFlags = ['-Dspring.profiles.active=${SPRING_ACTIVE_PROFILE}']
+            ports = ['8080/tcp', '3306/tcp']
+        }
+
+    }
+}
 
 
 // 커밋 컨벤션을 지키기 위한 commit-msg 스크립트를 local git hook에 적용하는 task

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,15 +10,17 @@ server:
         http-only: true
 
 spring:
-  docker.compose.skip.in-tests: true # docker compose support 지원 안함
-  data:
-    redis:
-      host: ${celog-redis-host}
-      port: ${celog-redis-port}
-      password: ${celog-redis-password}
-      username: ${celog-redis-username}
+  # docker compose support (로컬 환경을 구성하기 위한 목적이므로)
+  docker:
+    compose:
+      enabled: false
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${celog-mysql-url}
     username: ${celog-mysql-username}
     password: ${celog-mysql-password}
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: ${celog-jpa-ddl-auto}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,15 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+  cloud:
+    aws:
+      s3:
+        endpoint: ${npc-end-point}
+        region: ${ncp-region}
+      credentials:
+        access-key: ${npc-access-key}
+        secret-key: ${npc-secret-key}
+
 ncp:
   region: ${ncp-region}
   end-point: ${npc-end-point}


### PR DESCRIPTION
- Github Actions을 사용해 구현하였습니다.
  - Jib을 사용해 이미지를 NCP Container Registry에 등록합니다.
  - SSH로 서버 인스턴스에 접근하여 새로운 이미지를 받아 재실행합니다.
  - 서버 인스턴스는 Docker 환경에서 실행됩니다.

이전에 무중단 배포를 해보고 말했는데, 벡엔드 개발자로서는 투자 대비 결과가 별로라고 생각해서 간단하게 구현했습니다.

closes #41 #42