### PR TITLE
feat: 비인증 사용자의 요청 시 NPE가 발생하는 문제 수정 추가

### DIFF
--- a/src/main/java/dev/sijunyang/celog/surpport/security/AuthenticatedUserManagerImpl.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/AuthenticatedUserManagerImpl.java
@@ -3,7 +3,11 @@ package dev.sijunyang.celog.surpport.security;
 import dev.sijunyang.celog.api.AuthenticatedUserManager;
 import dev.sijunyang.celog.core.global.enums.Role;
 
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
@@ -12,23 +16,50 @@ import org.springframework.stereotype.Component;
  *
  * @author Sijun Yang
  */
-// TODO 익명 사용자의 경우, OAuth2AuthenticationToken 을 가지지 않는다. 해당 경우에 대한 조건을 고려해서 수정해야 한다.
 @Component
 public class AuthenticatedUserManagerImpl implements AuthenticatedUserManager {
 
     @Override
     public Long getId() {
-        // OAuth2 사용자의 이름(명)을 가져와 Long 타입으로 변환하여 반환합니다.
-        OAuth2User oAuth2User = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return Long.valueOf(oAuth2User.getName());
+        Authentication authenticationOrNull = SecurityContextHolder.getContext().getAuthentication();
+        if (authenticationOrNull == null || authenticationOrNull instanceof AnonymousAuthenticationToken) {
+            throw new AuthenticationCredentialsNotFoundException(
+                    "사용자를 식별할 수 없습니다. authentication: " + authenticationOrNull);
+        }
+
+        // 이제 null이 확실하게 아니므로 변수명에서 OrNull 제거.
+        Authentication authentication = authenticationOrNull;
+
+        // 인증 된 사용자의 이름(명)을 가져와 Long 타입으로 변환하여 반환합니다.
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+            return Long.valueOf(oAuth2User.getName());
+        }
+        else {
+            throw new RuntimeException("지원하지 않는 authentication 객체입니다. authentication: " + authentication);
+        }
     }
 
     @Override
     public Role getRole() {
-        // OAuth2 사용자의 "role" 속성 값을 가져와 Role 타입으로 반환합니다.
+        Authentication authenticationOrNull = SecurityContextHolder.getContext().getAuthentication();
+        if (authenticationOrNull == null || authenticationOrNull instanceof AnonymousAuthenticationToken) {
+            throw new AuthenticationCredentialsNotFoundException(
+                    "사용자를 식별할 수 없습니다. authentication: " + authenticationOrNull);
+        }
+
+        // 이제 null이 확실하게 아니므로 변수명에서 OrNull 제거.
+        Authentication authentication = authenticationOrNull;
+
+        // 인증 된 사용자의 "role" 속성 값을 가져와 Role 타입으로 반환합니다.
         // 인증 된 사용자는 항상 "role" 속성 값을 가지고 있습니다.
-        OAuth2User oAuth2User = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return oAuth2User.getAttribute("role");
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+            return oAuth2User.getAttribute("role");
+        }
+        else {
+            throw new RuntimeException("지원하지 않는 authentication 객체입니다. authentication: " + authentication);
+        }
     }
 
 }


### PR DESCRIPTION
AuthenticatedUserManagerImpl 에서 비인증 사용자가 특정 API로 요청을 보내는 경우, NPE가 발생하는 문제가 있었음.
검증을 로직을 추가해서 NPE 대신 명시된 예외가 발생하도록 기능 추가