### PR TITLE
feat: 테스트 전용 Header 기반 인증기능 구현

### DIFF
--- a/src/main/java/dev/sijunyang/celog/surpport/security/AuthenticatedUserManagerImpl.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/AuthenticatedUserManagerImpl.java
@@ -21,16 +21,12 @@ public class AuthenticatedUserManagerImpl implements AuthenticatedUserManager {
 
     @Override
     public Long getId() {
-        Authentication authenticationOrNull = SecurityContextHolder.getContext().getAuthentication();
-        if (authenticationOrNull == null || authenticationOrNull instanceof AnonymousAuthenticationToken) {
-            throw new AuthenticationCredentialsNotFoundException(
-                    "사용자를 식별할 수 없습니다. authentication: " + authenticationOrNull);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+            throw new AuthenticationCredentialsNotFoundException("사용자를 식별할 수 없습니다. authentication: " + authentication);
         }
 
-        // 이제 null이 확실하게 아니므로 변수명에서 OrNull 제거.
-        Authentication authentication = authenticationOrNull;
-
-        // 인증 된 사용자의 이름(명)을 가져와 Long 타입으로 변환하여 반환합니다.
+        // 인증 된 사용자의 이름 속성을 가져와 Long 타입으로 변환하여 반환합니다.
         if (authentication instanceof OAuth2AuthenticationToken) {
             OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
             return Long.valueOf(oAuth2User.getName());
@@ -42,17 +38,13 @@ public class AuthenticatedUserManagerImpl implements AuthenticatedUserManager {
 
     @Override
     public Role getRole() {
-        Authentication authenticationOrNull = SecurityContextHolder.getContext().getAuthentication();
-        if (authenticationOrNull == null || authenticationOrNull instanceof AnonymousAuthenticationToken) {
-            throw new AuthenticationCredentialsNotFoundException(
-                    "사용자를 식별할 수 없습니다. authentication: " + authenticationOrNull);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+            throw new AuthenticationCredentialsNotFoundException("사용자를 식별할 수 없습니다. authentication: " + authentication);
         }
 
-        // 이제 null이 확실하게 아니므로 변수명에서 OrNull 제거.
-        Authentication authentication = authenticationOrNull;
-
-        // 인증 된 사용자의 "role" 속성 값을 가져와 Role 타입으로 반환합니다.
-        // 인증 된 사용자는 항상 "role" 속성 값을 가지고 있습니다.
+        // Authentication 객체를 가져와 Role 객체를 가져온다.
+        // 인증 된 사용자는 항상 속성 값으로 Role 객체를 가지고 있다.
         if (authentication instanceof OAuth2AuthenticationToken) {
             OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
             return oAuth2User.getAttribute(CustomOauth2UserService.CELOG_ROLE);

--- a/src/main/java/dev/sijunyang/celog/surpport/security/AuthenticatedUserManagerImpl.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/AuthenticatedUserManagerImpl.java
@@ -55,7 +55,7 @@ public class AuthenticatedUserManagerImpl implements AuthenticatedUserManager {
         // 인증 된 사용자는 항상 "role" 속성 값을 가지고 있습니다.
         if (authentication instanceof OAuth2AuthenticationToken) {
             OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-            return oAuth2User.getAttribute("role");
+            return oAuth2User.getAttribute(CustomOauth2UserService.CELOG_ROLE);
         }
         else {
             throw new RuntimeException("지원하지 않는 authentication 객체입니다. authentication: " + authentication);

--- a/src/main/java/dev/sijunyang/celog/surpport/security/CustomOauth2UserService.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/CustomOauth2UserService.java
@@ -26,11 +26,22 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 @RequiredArgsConstructor
 public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
-    private static final String ROLE_PREFIX = "ROLE_";
+    // TODO public static final 을 관리하는 클래스를 따로 두는게 좋을듯
 
-    private static final String CELOG_USER_ID = "celog_user_id";
+    /**
+     * Spring Security 의 인증 값의 접두사로 사용되는 문자열입니다. 예를 들어, 권한이 ADMIN 경우 ROLE_ADMIN으로 사용됩니다.
+     */
+    public static final String ROLE_PREFIX = "ROLE_";
 
-    private static final String CELOG_ROLE = "celog_role";
+    /**
+     * Spring Security 의 AuthenticationToken의 속성 중에 식별자를 담은 속성의 키로 사용되는 문자열입니다.
+     */
+    public static final String CELOG_USER_ID = "celog_user_id";
+
+    /**
+     * Spring Security 의 AuthenticationToken속성 중에 사용자의 권한을 담은 속성의 키로 사용되는 문자열입니다.
+     */
+    public static final String CELOG_ROLE = "celog_role";
 
     private final UserService userService;
 

--- a/src/main/java/dev/sijunyang/celog/surpport/security/HeaderAuthenticationFilter.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/HeaderAuthenticationFilter.java
@@ -1,0 +1,81 @@
+package dev.sijunyang.celog.surpport.security;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import dev.sijunyang.celog.core.global.enums.Role;
+import dev.sijunyang.celog.core.global.error.nextVer.InvalidInputException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class HeaderAuthenticationFilter extends OncePerRequestFilter {
+
+    // 테스트 시 다음과 같은 curl 사용 가능
+    // curl -X GET \
+    // -H "TEST_AUTH: true" \
+    // -b "USER_ID=123;USER_ROLE=ADMIN" \
+    // http://localhost:8080/some-endpoint
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String testAuth = request.getHeader("TEST_AUTH");
+        if (testAuth == null || !testAuth.equals("true")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            throw new InvalidInputException(
+                    "TEST_AUTH 기능을 사용하기 위해선 USER_ID와 USER_ROLE 쿠키가 설정되어야 합니다. 아무 쿠키도 입력되지 않았습니다.");
+        }
+
+        String userId = null;
+        String userRole = null;
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("USER_ID")) {
+                userId = cookie.getValue();
+            }
+            else if (cookie.getName().equals("USER_ROLE")) {
+                userRole = cookie.getValue();
+            }
+        }
+
+        if (userId == null || userRole == null) {
+            throw new InvalidInputException(
+                    "TEST_AUTH 기능을 사용하기 위해선 USER_ID와 USER_ROLE 쿠키가 설정되어야 합니다. cookies: " + Arrays.toString(cookies));
+        }
+
+        Role role = Role.valueOf(userRole);
+        Map<String, Object> attributes = Map.of(CustomOauth2UserService.CELOG_USER_ID, Long.parseLong(userId),
+                CustomOauth2UserService.CELOG_ROLE, role);
+
+        // TODO 왜 Collections.singleton가 꼭 필요한거지?
+        Collection<GrantedAuthority> authorities = Collections
+            .singleton(new SimpleGrantedAuthority(CustomOauth2UserService.ROLE_PREFIX + role.name()));
+
+        OAuth2AuthenticationToken token = new OAuth2AuthenticationToken(
+                new DefaultOAuth2User(authorities, attributes, CustomOauth2UserService.CELOG_USER_ID),
+                Collections.emptyList(), "test-by-celog");
+
+        SecurityContextHolder.getContext().setAuthentication(token);
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/dev/sijunyang/celog/surpport/security/WebSecurityConfig.java
+++ b/src/main/java/dev/sijunyang/celog/surpport/security/WebSecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @RequiredArgsConstructor
@@ -21,6 +22,8 @@ public class WebSecurityConfig {
 
     private final AccessDeniedHandler accessDeniedHandler;
 
+    private final HeaderAuthenticationFilter headerAuthenticationFilter;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.formLogin(AbstractHttpConfigurer::disable)
@@ -28,6 +31,7 @@ public class WebSecurityConfig {
             // CSRF 토큰을 사용하는게 안전하나, 실제 서비스가 아니므로 당장은 신경쓰기 않기로 함
             .csrf(AbstractHttpConfigurer::disable)
             .oauth2Login(Customizer.withDefaults())
+            .addFilterAfter(this.headerAuthenticationFilter, CorsFilter.class)
             .exceptionHandling((configurer) -> configurer.accessDeniedHandler(this.accessDeniedHandler)
                 .authenticationEntryPoint(this.authenticationEntryPoint))
             .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests.anyRequest().permitAll());


### PR DESCRIPTION
`HeaderAuthenticationFilter`에서 헤더 값과 쿠키 값 기반으로 인증을 처리합니다.

이 객체가 필요한 문맥을 파악하기 위해선 #52 를 참고해주세요.

추가로 `CustomOauth2UserService`에서 사용하는 상수인 변수(`static final`)를 public하게 만들고, 문자열 대신 해당 변수를 사용하도록 변경하였습니다.

문자열을 사용하는 경우 변경이 발생했을 때 대응하기 어렵기 때문입니다.

closes #52 