### PR TITLE
feat: Spring Actuator 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,8 @@ spring:
   servlet:
     multipart:
       max-file-size: 1MB
-#  session:
-#    store-type: redis
+  #  session:
+  #    store-type: redis
   security:
     oauth2:
       client:
@@ -36,3 +36,10 @@ ncp:
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+      base-path: "/actuator"


### PR DESCRIPTION
보안과 관련된 부분은 신경쓰지 않고 모든 기능을 사용한다.

성능테스트 외에 실제로 서버가 켜 있는 시간은 적기도 하고, 
도입 목적이 서버 상태를 확인하고 제어하기 위함이기 때문이다.